### PR TITLE
Week1: 박유현 문제풀이

### DIFF
--- a/yuhyun/Stack-Queue/두 큐 합 같게 만들기.js
+++ b/yuhyun/Stack-Queue/두 큐 합 같게 만들기.js
@@ -1,0 +1,37 @@
+function solution(queue1, queue2) {
+  const INVALID = -1;
+
+  const add = (a, b) => a + b;
+  const isOdd = (num) => num % 2 === 1;
+
+  const list = [...queue1, ...queue2];
+
+  const total = list.reduce(add, 0);
+  if (isOdd(total)) {
+    return INVALID;
+  }
+
+  let result = 0;
+  let start = 0;
+  let end = queue1.length;
+  let cur = queue1.reduce(add, 0);
+  const target = total / 2;
+
+  while (end <= list.length) {
+    if (cur === target) {
+      return result;
+    }
+
+    if (cur < target) {
+      cur += list[end];
+      end += 1;
+    } else {
+      cur -= list[start];
+      start += 1;
+    }
+
+    result += 1;
+  }
+
+  return INVALID;
+}

--- a/yuhyun/Stack-Queue/캐시.js
+++ b/yuhyun/Stack-Queue/캐시.js
@@ -1,0 +1,118 @@
+function solution(cacheSize, cities) {
+  const HIT = 1;
+  const MISS = 5;
+
+  if (cacheSize === 0) {
+    return cities.length * MISS;
+  }
+
+  let result = 0;
+  const cache = new DoublyLinkedList();
+
+  cities
+    .map((city) => city.toLowerCase())
+    .forEach((city) => {
+      const isHit = cache.remove(city);
+
+      if (isHit) {
+        cache.addLast(city);
+        result += HIT;
+        return;
+      }
+
+      if (cache.length() >= cacheSize) {
+        cache.removeFirst();
+      }
+
+      cache.addLast(city);
+      result += MISS;
+    });
+
+  return result;
+}
+
+function Node(value) {
+  this.value = value;
+  this.prev = null;
+  this.next = null;
+}
+
+class DoublyLinkedList {
+  #head = null;
+  #tail = null;
+  #size = 0;
+
+  addLast(value) {
+    const newNode = new Node(value);
+
+    if (this.isEmpty()) {
+      this.#head = newNode;
+    } else {
+      newNode.prev = this.#tail;
+      this.#tail.next = newNode;
+    }
+
+    this.#tail = newNode;
+    this.#size += 1;
+  }
+
+  remove(value) {
+    let cur = this.#head;
+
+    while (cur) {
+      if (cur.value === value) {
+        break;
+      }
+
+      cur = cur.next;
+    }
+
+    if (!cur) {
+      return false;
+    }
+
+    const prevNode = cur.prev;
+    const nextNode = cur.next;
+
+    if (prevNode) {
+      prevNode.next = nextNode;
+    }
+
+    if (nextNode) {
+      nextNode.prev = prevNode;
+    }
+
+    if (cur === this.#head) {
+      this.#head = nextNode;
+    }
+
+    if (cur === this.#tail) {
+      this.#tail = prevNode;
+    }
+
+    this.#size -= 1;
+    return true;
+  }
+
+  removeFirst() {
+    if (this.isEmpty()) {
+      return false;
+    }
+
+    const nextNode = this.#head.next;
+    if (nextNode) {
+      nextNode.prev = null;
+    }
+    this.#head = nextNode;
+    this.#size -= 1;
+    return true;
+  }
+
+  isEmpty() {
+    return this.#size === 0;
+  }
+
+  length() {
+    return this.#size;
+  }
+}

--- a/yuhyun/String/문자열 압축.js
+++ b/yuhyun/String/문자열 압축.js
@@ -1,0 +1,30 @@
+function solution(s) {
+  let min = s.length;
+
+  for (let unit = 1; unit <= s.length / 2; unit++) {
+    let compressed = 0;
+    let cnt = 1;
+    let prevWord = s.substring(0, unit);
+
+    for (let start = unit; start < s.length; start += unit) {
+      if (min <= compressed) {
+        break;
+      }
+
+      const curWord = s.substring(start, start + unit);
+      if (prevWord === curWord) {
+        cnt += 1;
+        continue;
+      }
+
+      compressed += unit + (cnt === 1 ? 0 : String(cnt).length);
+      cnt = 1;
+      prevWord = curWord;
+    }
+
+    compressed += prevWord.length + (cnt === 1 ? 0 : String(cnt).length);
+    min = Math.min(min, compressed);
+  }
+
+  return min;
+}

--- a/yuhyun/String/압축.js
+++ b/yuhyun/String/압축.js
@@ -1,0 +1,29 @@
+function solution(msg) {
+  const result = [];
+  const dict = new Map(
+    [..."ABCDEFGHIJKLMNOPQRSTUVWXYZ"].map((char, i) => [char, i + 1])
+  );
+
+  let start = 0;
+  let end = 1;
+  while (start < msg.length) {
+    const word = msg.substring(start, end);
+    if (!dict.has(word)) {
+      const matched = msg.substring(start, end - 1);
+      result.push(dict.get(matched));
+      dict.set(word, dict.size + 1);
+
+      start = end - 1;
+      end = start + 1;
+      continue;
+    }
+
+    if (end === msg.length) {
+      result.push(dict.get(word));
+      break;
+    }
+
+    end += 1;
+  }
+  return result;
+}


### PR DESCRIPTION
## 두 큐 합 같게 만들기
- 두 큐를 하나의 배열로 만든 후 투 포인터 구간 합으로 풀이
- 반복문 조건
	- 처음에 `result < queue1.length`로 설정했었는데 틀림
		- 한 큐에서 모든 원소를 pop한 횟수라면 모든 경우의 수를 다 탐색한 것으로 잘못 생각함
	- `end <= list.length`로 설정하니 맞음
	- 위 방법은 때려 맞춘 거라 찾아보니 큐의 길이를 $n$ 일 때 pop 횟수가 $4n$ 번이 되면, 적어도 어느 한 큐는 pop이 $2n$번 이루어져 처음 상태로 돌아왔음을 알 수 있다함([링크](https://blog.encrypted.gg/1076))

## 캐시
- 노드 추가 / 삭제가 빈번하기 때문에 이중 연결 리스트가 적합하다고 생각함
	- 다른 사람의 풀이를 보니 `splice`, `unshift` 해도 시간 초과 안 뜸
- 연결 리스트 문제가 나오면 그때 그때 로직에 맞게 구현하는데 실수가 잦음. 일반화된 연결 리스트 자료 구조를 하나 잡고 가는게 맞을 듯?

## 문자열 압축
- 문자열의 길이가 1 이상 1,000이하이므로 1개 단위 ~ 1,000개 단위로 잘라 압축 길이를 구하는 로직이어도 $1000^2$ 이므로 시간 초과가 안 될 것 같았음

## 압축
- 사전 조회가 많기 때문에 Map 자료구조 이용
- 마지막 입력은 사전에 존재하거나 한 글자이므로 반드시 사전에 존재함
- 반복문 조건이 `true` 여도 동작하는데 구린 것 같음..개선할 방법이 안 보임
