### PR TITLE
Week5: 박유현 문제풀이

### DIFF
--- a/yuhyun/BinarySearch/순위 검색.js
+++ b/yuhyun/BinarySearch/순위 검색.js
@@ -1,0 +1,71 @@
+function solution(info, query) {
+  const caseMap = (() => {
+    const AND = " and ";
+    const ANY = "-";
+    const N_FIELD = 4;
+    const TOTAL_CASE = 2 ** N_FIELD;
+
+    const scoreAscendingFn = (a, b) => a - b;
+
+    const map = new Map();
+
+    const addInfo = (infoString) => {
+      const infoArray = infoString.split(" ");
+      const score = parseInt(infoArray.pop(), 10);
+
+      for (let curCase = 0; curCase < TOTAL_CASE; curCase += 1) {
+        const curCaseBinary = curCase.toString(2).padStart(N_FIELD, "0");
+        const curKey = infoArray
+          .map((curField, index) => {
+            const anyField = curCaseBinary[index] === "0";
+            return anyField ? ANY : curField;
+          })
+          .join(AND);
+
+        const scoreArray = map.get(curKey) ?? [];
+        scoreArray.push(score);
+        map.set(curKey, scoreArray);
+      }
+    };
+
+    const sort = () => {
+      map.forEach((scoreArray) => scoreArray.sort(scoreAscendingFn));
+    };
+
+    const getScoreArray = (key) => {
+      return map.get(key);
+    };
+
+    return { addInfo, sort, getScoreArray };
+  })();
+
+  const lowerBound = (array, target) => {
+    let low = -1;
+    let high = array.length;
+    while (low + 1 < high) {
+      const mid = Math.floor((low + high) / 2);
+      if (array[mid] >= target) {
+        high = mid;
+        continue;
+      }
+      low = mid;
+    }
+    return high;
+  };
+
+  const parseQuery = (queryString) => {
+    const queryArray = queryString.split(" ");
+    const score = parseInt(queryArray.pop(), 10);
+    const caseMapKey = queryArray.join(" ");
+    return [caseMapKey, score];
+  };
+
+  const count = ([caseMapKey, minScore]) => {
+    const scoreArray = caseMap.getScoreArray(caseMapKey) ?? [];
+    return scoreArray.length - lowerBound(scoreArray, minScore);
+  };
+
+  info.forEach(caseMap.addInfo);
+  caseMap.sort();
+  return query.map(parseQuery).map(count);
+}

--- a/yuhyun/BinarySearch/징검다리 건너기.js
+++ b/yuhyun/BinarySearch/징검다리 건너기.js
@@ -1,0 +1,32 @@
+function solution(stones, k) {
+  let left = 1;
+  let right = 200_000_000;
+  const { length } = stones;
+
+  while (left + 1 < right) {
+    const mid = Math.floor((left + right) / 2);
+
+    let curK = 0;
+    for (let i = 0; i < length; i++) {
+      if (stones[i] >= mid) {
+        curK = 0;
+        continue;
+      }
+
+      curK += 1;
+
+      if (curK >= k) {
+        break;
+      }
+    }
+
+    if (curK < k) {
+      left = mid;
+      continue;
+    }
+
+    right = mid;
+  }
+
+  return left;
+}

--- a/yuhyun/DFS-BFS/네트워크.js
+++ b/yuhyun/DFS-BFS/네트워크.js
@@ -1,0 +1,64 @@
+function solution(n, computers) {
+  const createQueue = () => {
+    let head = 0;
+    const array = [];
+
+    const push = (value) => {
+      array.push(value);
+    };
+
+    const pop = () => {
+      const result = array[head];
+      head += 1;
+      return result;
+    };
+
+    const isEmpty = () => {
+      return array.length - head === 0;
+    };
+
+    return { push, pop, isEmpty };
+  };
+
+  const bfs = (start, visited, graph) => {
+    const queue = createQueue();
+
+    visited[start] = true;
+    queue.push(start);
+
+    while (!queue.isEmpty()) {
+      const cur = queue.pop();
+      const connectedFromCur = graph[cur];
+
+      connectedFromCur.forEach((connected, node) => {
+        if (visited[node]) {
+          return;
+        }
+
+        if (cur === node) {
+          return;
+        }
+
+        if (!connected) {
+          return;
+        }
+
+        queue.push(node);
+        visited[node] = true;
+      });
+    }
+  };
+
+  let result = 0;
+  const visited = Array(n).fill(false);
+  for (let start = 0; start < n; start += 1) {
+    if (visited[start]) {
+      continue;
+    }
+
+    result += 1;
+    bfs(start, visited, computers);
+  }
+
+  return result;
+}

--- a/yuhyun/DFS-BFS/카드 짝 맞추기.js
+++ b/yuhyun/DFS-BFS/카드 짝 맞추기.js
@@ -1,0 +1,225 @@
+function solution(board, r, c) {
+  const [PAIR_A, PAIR_B] = [0, 1];
+  const ENTER = 1;
+
+  const UP = [-1, 0];
+  const LEFT = [0, 1];
+  const DOWN = [1, 0];
+  const RIGHT = [0, -1];
+
+  const isEmpty = (col) => {
+    return col === 0;
+  };
+
+  const createSingleMoveMethod = ([dr, dc]) => {
+    return (r, c, board) => {
+      const R = board.length;
+      const C = board[0].length;
+
+      const nextR = r + dr;
+      const nextC = c + dc;
+
+      return outOfRange(nextR, nextC, R, C) ? [[r, c], 0] : [[nextR, nextC], 1];
+    };
+  };
+
+  const createCtrlMoveMethod = ([dr, dc]) => {
+    return (r, c, board) => {
+      const R = board.length;
+      const C = board[0].length;
+
+      let curR = r;
+      let curC = c;
+      let moved = false;
+
+      while (true) {
+        const nextR = curR + dr;
+        const nextC = curC + dc;
+
+        if (outOfRange(nextR, nextC, R, C)) {
+          break;
+        }
+
+        curR = nextR;
+        curC = nextC;
+        moved = true;
+
+        if (!isEmpty(board[nextR][nextC])) {
+          break;
+        }
+      }
+
+      return [[curR, curC], moved ? 1 : 0];
+    };
+  };
+
+  const moveMethods = [
+    createSingleMoveMethod(UP),
+    createSingleMoveMethod(LEFT),
+    createSingleMoveMethod(DOWN),
+    createSingleMoveMethod(RIGHT),
+    createCtrlMoveMethod(UP),
+    createCtrlMoveMethod(LEFT),
+    createCtrlMoveMethod(DOWN),
+    createCtrlMoveMethod(RIGHT),
+  ];
+
+  const createCardMap = (board) => {
+    const result = new Map();
+    board.forEach((row, rowIndex) => {
+      row.forEach((col, colIndex) => {
+        if (isEmpty(col)) {
+          return;
+        }
+
+        const curCardPosition = [rowIndex, colIndex];
+        const cardsPosition = result.get(col) ?? [];
+        result.set(col, [...cardsPosition, curCardPosition]);
+      });
+    });
+    return result;
+  };
+
+  const calcShortestPath = ([fromR, fromC], [toR, toC], board) => {
+    const R = board.length;
+    const C = board[0].length;
+
+    const queue = createQueue();
+    const minDistance = Array.from(Array(R), () => Array(C).fill(Infinity));
+
+    queue.enqueue([fromR, fromC]);
+    minDistance[fromR][fromC] = 0;
+
+    while (!queue.isEmpty()) {
+      const [curR, curC] = queue.dequeue();
+      const curDistance = minDistance[curR][curC];
+
+      if (isSamePosition([curR, curC], [toR, toC])) {
+        break;
+      }
+
+      moveMethods.forEach((move) => {
+        const [[nextR, nextC], distance] = move(curR, curC, board);
+        const nextDistance = curDistance + distance;
+
+        if (nextDistance >= minDistance[nextR][nextC]) {
+          return;
+        }
+
+        minDistance[nextR][nextC] = nextDistance;
+        queue.enqueue([nextR, nextC]);
+      });
+    }
+
+    return minDistance[toR][toC];
+  };
+
+  const createCardOrders = (orderPermutations, cardMap) => {
+    const dfs = (level, order, history, result) => {
+      if (level === order.length) {
+        result.push([...history]);
+        return;
+      }
+
+      const card = cardMap.get(order[level]);
+      history.push(card[PAIR_A], card[PAIR_B]);
+      dfs(level + 1, order, history, result);
+      history.pop();
+      history.pop();
+
+      history.push(card[PAIR_B], card[PAIR_A]);
+      dfs(level + 1, order, history, result);
+      history.pop();
+      history.pop();
+    };
+
+    return orderPermutations.flatMap((order) => {
+      const result = [];
+      dfs(0, order, [], result);
+      return result;
+    }, 1);
+  };
+
+  const traverse = (startR, startC, order, board) => {
+    let fromR = startR;
+    let fromC = startC;
+    const copiedBoard = board.map((row) => [...row]);
+
+    const step = ([toR, toC]) => {
+      const matched =
+        !isSamePosition([toR, toC], [fromR, fromC]) &&
+        board[toR][toC] === board[fromR][fromC];
+
+      const distance = calcShortestPath(
+        [fromR, fromC],
+        [toR, toC],
+        copiedBoard
+      );
+
+      if (matched) {
+        copiedBoard[fromR][fromC] = copiedBoard[toR][toC] = 0;
+      }
+
+      fromR = toR;
+      fromC = toC;
+
+      return matched ? ENTER + distance + ENTER : distance;
+    };
+
+    const sum = (acc, cur) => acc + cur;
+
+    return order.map(step).reduce(sum, 0);
+  };
+
+  const cardMap = createCardMap(board);
+  const nCard = cardMap.size;
+  const cardOrders = createCardOrders(
+    getPermutations([...cardMap.keys()], nCard),
+    cardMap
+  );
+
+  return Math.min(...cardOrders.map((order) => traverse(r, c, order, board)));
+}
+
+function outOfRange(r, c, R, C) {
+  return r < 0 || c < 0 || R <= r || C <= c;
+}
+
+function getPermutations(array, nPick) {
+  if (nPick === 1) {
+    return array.map((value) => [value]);
+  }
+
+  return array.flatMap((value, index) => {
+    const permutations = getPermutations(
+      array.filter((_, i) => i !== index),
+      nPick - 1
+    );
+    return permutations.map((permutation) => [value, ...permutation]);
+  }, 1);
+}
+
+function createQueue() {
+  let head = 0;
+  const queue = [];
+
+  const enqueue = (value) => {
+    queue.push(value);
+  };
+
+  const dequeue = () => {
+    const value = queue[head];
+    head += 1;
+    return value;
+  };
+
+  const isEmpty = () => {
+    return queue.length - head === 0;
+  };
+
+  return { enqueue, dequeue, isEmpty };
+}
+
+function isSamePosition([r1, c1], [r2, c2]) {
+  return r1 === r2 && c1 === c2;
+}


### PR DESCRIPTION
## 네트워크
- connected component 카운트 = 모든 노드 방문할 때까지 BFS 호출 횟수

## 카드 짝 맞추기
- 보드판도 4x4고, 카드 갯수도 최대 12개이기 때문에 완전 탐색이 가능하다.
- 매칭할 카드 순서 구하기
	- 먼저 카드 번호 순열을 구한다.
		- ex. 1번 카드 > 2번 카드 > 3번 카드
	- DFS를 이용해 카드 번호 순열 결괏값에서 1번 카드 A -> 1번 카드 B 순으로 매칭할지, 1번 카드 B -> 1번 카드 B 순으로 매칭할지를 매칭할 카드 순서에 추가한다.
		- ex. 1번 카드 A > 1번 카드 B > 2번 카드 A > 2번 카드 B > 3번 카드 A > 3번 카드 B
- BFS를 이용해 현재 보드판에서 A 위치에서 B 위치로 이동할 수 있는 최단거리를 구한다.
- 매칭할 카드 순서에 따라 최단거리를 구한 후 최솟값을 반환한다.

## 순위 검색
- Map<(개발언어, 직군, 경력, 소울푸드), 코테 점수 오름차순 지원자 배열>
- 쿼리로 Map의 키를 만들고, 코테 점수 오름차순 지원자 배열을 받아 lower bound를 이용해 쿼리에 만족하는 지원자 중 가장 코테 점수가 낮은 지원자의 인덱스를 구한다.

## 징검다리 건너기
- 건널 수 있는 친구 수에 제한이 없다.
- 돌 갯수는 최대 200,000개이고 돌마다 건널 수 있는 친구의 수는 200,000,000 이다.
	- 건널 수 있는 친구 수는 돌마다 건널 수 있는 친구의 수 중 최댓값으로 제한할 수 있다.
- 친구 한 명씩 건너서 결과를 구하면 시간 복잡도가 200,000 * 200,000,000 라서 시간 초과가 분명해 보인다.
	- 한 번에 여러 명을 건너게 해 건널 수 있는지 / 없는지 체크해 이분 탐색으로 건널 친구 수를 좁혀가면 될 것 같다. (log 200,000) * 200,000,000
- 한 번에 여러 명을 건너게 해 건널 수 있는지 / 없는지는 어떻게 체크할 수 있을까
	- 이번에 건널 친구 수를 m이라 해보자.
	- 돌을 건너면서 해당 돌을 건널 수 있는 친구의 수가 m 보다 같거나 크면 괜찮다.
	- 돌을 건너면서 해당 돌을 건널 수 있는 친구의 수가 m 보다 작으면 건너뛴 거리를 기록해야 한다.
		- 기록 중인 건너뛴 거리가 k보다 작은데 다음 돌에서 모두 건널 수 있으면 기록은 초기화된다.
	- 기록 중인 건너뛴 거리가 k보다 크거나 같아지면 m 명은 건널 수 없다.
- 효율성;;
  - 배열 고차함수 -> for 문
  - 함수 호출 -> X
```js
function solution(stones, k) {
    let left = 1;
    let right = 200_000_000;
    const { length } = stones;
    
    while (left + 1 < right) {
        const mid = Math.floor((left + right) / 2);
        
        let curK = 0;
        for (let i = 0; i < length; i++) {
            if (stones[i] >= mid) {
                curK = 0;
                continue;
            }
            
            curK += 1;
            
            if (curK >= k) {
                break;
            }
        }
        
        if (curK < k) {
            left = mid;
            continue;
        }
        
        right = mid;
    }
    
    return left;
}
```

효율성  테스트

|테스트   |결과   |
|---|---|
|테스트 1 〉|통과 (17.36ms, 41MB)|
|테스트 2 〉|통과 (17.81ms, 40.9MB)|
|테스트 3 〉|통과 (15.77ms, 40.9MB)|
|테스트 4 〉|통과 (7.03ms, 40.9MB)|
|테스트 5 〉|통과 (8.96ms, 40.9MB)|
|테스트 6 〉|통과 (8.65ms, 41.1MB)|
|테스트 7 〉|통과 (18.03ms, 41.1MB)|
|테스트 8 〉|통과 (19.18ms, 40.9MB)|
|테스트 9 〉|통과 (19.61ms, 40.9MB)|
|테스트 10 〉|통과 (18.79ms, 41MB)|
|테스트 11 〉|통과 (17.32ms, 41MB)|
|테스트 12 〉|통과 (17.93ms, 41MB)|
|테스트 13 〉|통과 (9.33ms, 41.3MB)|
|테스트 14 〉|통과 (8.06ms, 41.8MB)|   

```js
function solution(stones, k) {
  const check = (nFriend) => {
    let curK = 0;
    return stones.every((stone) => {
      if (stone >= nFriend) {
        curK = 0;
        return true;
      }

      curK += 1;
      return curK < k;
    });
  };

  const binarySearch = (left, right, check) => {
    while (left + 1 < right) {
      const mid = Math.floor((left + right) / 2);
      if (check(mid)) {
        left = mid;
        continue;
      }
      right = mid;
    }
    return left;
  };

  return binarySearch(1, 200_000_000, check);
}
```

|테스트   |결과   |
|---|---|
|테스트 1 〉|통과 (60.37ms, 41.3MB)|
|테스트 2 〉|통과 (73.73ms, 40.9MB)|
|테스트 3 〉|통과 (72.20ms, 41MB)|
|테스트 4 〉|통과 (59.78ms, 40.9MB)|
|테스트 5 〉|실패 (시간 초과)|
|테스트 6 〉|실패 (시간 초과)|
|테스트 7 〉|실패 (시간 초과)|
|테스트 8 〉|실패 (시간 초과)|
|테스트 9 〉|통과 (86.88ms, 41MB)|
|테스트 10 〉|통과 (85.41ms, 41MB)|
|테스트 11 〉|통과 (79.56ms, 40.9MB)|
|테스트 12 〉|실패 (시간 초과)|
|테스트 13 〉|통과 (67.19ms, 40.2MB)|
|테스트 14 〉|통과 (57.85ms, 40.4MB)|
