### PR TITLE
Week5: 송민형 문제풀이

### DIFF
--- a/minhyung/week04/1, 2, 3 떨어트리기.js
+++ b/minhyung/week04/1, 2, 3 떨어트리기.js
@@ -2,6 +2,100 @@
 // 시작날짜: 2023.10.28
 // 시작시간: 14:10
 // 종료시간: 17:20(다른 문제 먼저 풀기)
-// 소요시간:
+// 소요시간: 엄청나게 오래걸림ㅋㅋ
 
-// 1, 2, 3 모든 경우의 수 다 떨궈보면 시간 초과 나서 다른 방법 생각 해봐야함.
+function solution(edges, target) {
+  const stackedOrder = Array.from(
+    { length: target.length + 1 },
+    () => new Array()
+  );
+  const paths = Array(target.length + 1).fill(0);
+  const G = new Map();
+
+  // index 1부터 시작하기 위한 더미 데이터 삽입
+  target.unshift(0);
+
+  // 그래프 생성
+  edges.forEach(([p, c]) => {
+    if (G.has(p)) G.get(p).push(c);
+    else G.set(p, [c]);
+  });
+
+  // 그래프 안의 하위 노드들을 오름차순으로 정렬
+  G.forEach((value, key) => {
+    const sortedNodes = value.sort((a, b) => a - b);
+    G.set(key, sortedNodes);
+  });
+
+  const findNowLeaf = (now = 1) => {
+    // 리프노드 도달 했다면
+    if (!G.get(now)) {
+      return now;
+    }
+    const nextPath = getNextPath(paths, G, now);
+    const nextNode = G.get(now)[nextPath];
+
+    return findNowLeaf(nextNode);
+  };
+
+  // 만약 stackedOrder의 모든 배열이 target num을 만들 수 없지만
+  // 숫자가 추가될 경우 만들 수 있으면 while문을 돌음.
+  let nowOrder = 1;
+  while (!canMakeTree(stackedOrder, target)) {
+    const nowLeaf = findNowLeaf();
+    stackedOrder[nowLeaf].push(nowOrder++);
+
+    // 만약 모든 조건이 만족하지도 않는데 target보다 숫자가 커지면
+    // 1을 target만큼 써도 쌓는게 불가능하므로 return [-1]을 해줌
+    const neverCanMakeTree = stackedOrder[nowLeaf].length > target[nowLeaf];
+    if (neverCanMakeTree) {
+      return [-1];
+    }
+  }
+
+  // 여기까지 무사히 오면 결과를 만들 수 있는 경우가 만들어짐.(최단으로)
+  // length를 가지고 3부터 시작해서 2, 1 숫자를 줄이며 target으로 만들어버림
+  const stackedNum = getStackedNum(stackedOrder, target);
+  const result = [];
+
+  stackedOrder.forEach((nowNode, i) => {
+    nowNode.forEach((nowOrder, j) => {
+      result[nowOrder] = stackedNum[i][j];
+    });
+  });
+
+  return result.slice(1);
+}
+
+function getNextPath(paths, graph, now) {
+  const max = graph.get(now).length;
+  if (paths[now] + 1 > max) {
+    paths[now] = 1;
+    return 0;
+  }
+  return paths[now]++;
+}
+
+function canMakeTree(stackedOrder, target) {
+  return stackedOrder.every(
+    (nowStack, idx) => target[idx] <= nowStack.length * 3
+  );
+}
+function getStackedNum(stackedOrder, target) {
+  return stackedOrder.map((nowNode, idx) => {
+    const stackedNumCnt = nowNode.length;
+    const sumedList = Array(nowNode.length).fill(1);
+    let sum = stackedNumCnt;
+
+    for (let i = stackedNumCnt - 1; i >= 0; i--) {
+      for (let j = 2; j > 0; j--) {
+        if (sum + j <= target[idx]) {
+          sumedList[i] += j;
+          sum += j;
+          break;
+        }
+      }
+    }
+    return sumedList;
+  });
+}

--- a/minhyung/week05/네트워크.js
+++ b/minhyung/week05/네트워크.js
@@ -1,4 +1,4 @@
-// 문제링크: https://school.programmers.co.kr/learn/courses/30/lessons/72412
+// 문제링크: https://school.programmers.co.kr/learn/courses/30/lessons/43162
 // 시작날짜: 2023.11.11
 // 시작시간: 13:12
 // 종료시간: 13:20

--- a/minhyung/week05/네트워크.js
+++ b/minhyung/week05/네트워크.js
@@ -1,0 +1,41 @@
+// 문제링크: https://school.programmers.co.kr/learn/courses/30/lessons/72412
+// 시작날짜: 2023.11.11
+// 시작시간: 13:12
+// 종료시간: 13:20
+// 소요시간: 00:08
+
+// 그래프를 dfs로 탐색함
+// visited로 방문여부 판단함.
+// 방문하지 않았던 노드만 방문하며
+// 처음 시작점이 방문하지 않았다면 ( 다른 그래프에 이어져 있지 않으면) result ++
+
+function solution(n, computers) {
+  const visited = Array(n).fill(false);
+  let result = 0;
+
+  const dfs = (now) => {
+    if (visited[now]) {
+      return;
+    }
+    visited[now] = true;
+
+    for (let i = 0; i < n; i++) {
+      const next = computers[now][i];
+
+      if (now === i || next === 0) {
+        continue;
+      }
+
+      dfs(i);
+    }
+  };
+
+  for (let i = 0; i < n; i++) {
+    if (!visited[i]) {
+      result++;
+    }
+    dfs(i);
+  }
+
+  return result;
+}

--- a/minhyung/week05/순위검색.js
+++ b/minhyung/week05/순위검색.js
@@ -1,0 +1,74 @@
+// 문제링크: https://school.programmers.co.kr/learn/courses/30/lessons/72412
+// 시작날짜: 2023.11.02
+// 시작시간: 15:49
+// 종료시간: 16:43
+// 소요시간: 01:06
+
+// 50000 * 15 = 75만
+// 그 후 dict에서 해당 값의 배열을 찾아서 이진탐색으로
+// 해당 값 '이상'인 값을 찾음
+// 그러면 lower bound를 적용하면될듯
+// queries.forEach에서 해당 쿼리의 배열 길이가 0일 경우 예외처리 안해서 런타임 에러 떴음
+// !searchTarget 으로 예외처리 해서 풀게됨
+
+function solution(infos, queries) {
+  const dict = new Map();
+  const result = [];
+
+  infos.forEach((info) => insert(dict, info));
+  dict.forEach((valueArr) => valueArr.sort((a, b) => a - b));
+
+  queries.forEach((query) => {
+    const [lang, category, career, food, score] = query
+      .replaceAll("and ", "")
+      .split(" ");
+    const key = `${lang}${category}${career}${food}`;
+    const searchTarget = dict.get(key);
+
+    if (!searchTarget) {
+      result.push(0);
+      return;
+    }
+    const pos = binarySearch(searchTarget, +score);
+    result.push(searchTarget.length - pos);
+  });
+
+  return result;
+}
+function insert(dict, info) {
+  const [lang, category, career, food, score] = info.split(" ");
+  const arr = [lang, category, career, food];
+
+  // 처음에 모든것에 대한 조합
+  setDict(dict, arr, score);
+
+  const combi = (now, arr) => {
+    for (let i = now; i < 4; i++) {
+      const before = [...arr];
+      arr[i] = "-";
+      // 해당 조합에 대해 추가로
+      setDict(dict, arr, score);
+
+      combi(i + 1, arr);
+      arr = before;
+    }
+  };
+
+  combi(0, arr);
+}
+function setDict(dict, arr, value) {
+  const key = arr.reduce((sum, now) => sum + now, "");
+  if (dict.has(key)) dict.get(key).push(+value);
+  else dict.set(key, [+value]);
+}
+function binarySearch(arr, findNum) {
+  let left = 0;
+  let right = arr.length;
+
+  while (left < right) {
+    const mid = Math.floor((left + right) / 2);
+    if (arr[mid] < findNum) left = mid + 1;
+    else right = mid;
+  }
+  return left;
+}

--- a/minhyung/week05/징검다리 건너기.js
+++ b/minhyung/week05/징검다리 건너기.js
@@ -1,0 +1,34 @@
+// 문제링크: https://school.programmers.co.kr/learn/courses/30/lessons/64062
+// 시작날짜: 2023.11.11
+// 시작시간: 15:45
+// 종료시간: 17:17
+// 소요시간: 01:32
+
+// 만약 숫자를 1씩 늘려서 탐색하면 무조건 시간초과가 남
+// 그래서 이진 탐색으로 최소 ~ 최대치를 탐색함 n  * logn
+// 이진탐색으로 찾아야 하는건 k가 되는 첫구간
+// mid값을 찾아서 stones를 순회해 해당값 미만인지 확인함
+// 그래서 미만인 경우가 k회 이상 있다면 못건넌다고 판단함
+// 그러고서 right = mid로 설정하고 앞쪽에도 못건너는 구간이 있는지 판단함.
+
+function solution(stones, k) {
+  let left = 1;
+  let right = 200000000;
+
+  const canCross = (mid) => {
+    let zeroCnt = 0;
+    for (let i = 0; i < stones.length; i++) {
+      if (stones[i] < mid) zeroCnt++;
+      else zeroCnt = 0;
+      if (zeroCnt >= k) return false;
+    }
+    return true;
+  };
+
+  while (left < right - 1) {
+    const mid = parseInt((left + right) / 2);
+    if (canCross(mid)) left = mid;
+    else right = mid;
+  }
+  return left;
+}

--- a/minhyung/week05/카드 짝 맞추기.js
+++ b/minhyung/week05/카드 짝 맞추기.js
@@ -1,0 +1,171 @@
+// 문제링크: school.programmers.co.kr/learn/courses/30/lessons/72415
+// 시작날짜: 2023.11.11
+// 시작시간: 15:43
+// 종료시간: 2시간 초과해서 해설 보고 풀이함.
+// 4 x 4 크기 격자로 표시됨
+// 8가지 캐릭터 그림이 그려진 카드 2장씩 무작위 배치
+// 유저가 2장 선택 후 같은그림
+//  -> 화면에서 사라짐
+// 같은그림 아님
+//  -> 원래 상태로 뒷면이 보이도록 뒤집힘
+// 모든 카드를 화면에서 사라지게 하면 게임 종료
+
+// 카드는 `커서`를 이용해 선택
+// 커서는 현재 선택한 위치를 표시하는 테두리 상자임.
+
+// 방향키 ←, ↑, ↓, → 중 하나를누르면 해당 방향으로 1칸이동
+// ctrl과 함께 누르면 해당 방향의 가장 가까운 카드로 한번에 이동
+//  -> 만약 해당 방향에 카드가 없으면 그 방향의 마지막 칸으로 이동
+// 만약 해당 누른 키 방향으로 이동 가능한 카드, 공간이 없다면 카드는 움직이지 않음
+
+// 뒤집을 때는 enter를 입력
+// 앞면이 1장이면 앞면 유지
+// 앞면이 2장일 때
+//  -> 같은 카드라면 화면에서 제거
+//  -> 다른 카드라면 원래대로 뒤집음
+
+// 남은 카드를 모두 제거하는데 필요한 키 조작 횟수의 최솟값 구하고싶음.
+// Enter, 방향키, ctrl + 방향키 = 조작 1회
+// ctrl + 방향키 누르면 바로 가지는게 아니라 다른 카드가 존재할 경우 그 만큼 dist가 늘어남
+
+function solution(board, r, c) {
+  const cardTypeNumber = getCardTypeNumber(board);
+  const cardLocation = getCardLocation(board);
+  const permu = getPermu(cardTypeNumber, [], new Set(), []);
+
+  let nowOrder = [];
+  let result = Infinity;
+
+  const dfs = (nowPos, dist, order) => {
+    if (order === cardTypeNumber) {
+      return dist;
+    }
+    const nowCard = nowOrder[order];
+    const [pos1, pos2] = cardLocation.get(nowCard);
+
+    // 현재좌표 -> 1 -> 2
+    const fromPos1Dist =
+      getToGoalDist(board, nowPos, pos1) + getToGoalDist(board, pos1, pos2);
+    // 현재좌표 -> 2 -> 1
+    const fromPos2Dist =
+      getToGoalDist(board, nowPos, pos2) + getToGoalDist(board, pos2, pos1);
+
+    board[pos1.y][pos1.x] = board[pos2.y][pos2.x] = 0;
+
+    const result = Math.min(
+      dfs(pos2, dist + fromPos1Dist + 2, order + 1),
+      dfs(pos1, dist + fromPos2Dist + 2, order + 1)
+    );
+
+    board[pos1.y][pos1.x] = board[pos2.y][pos2.x] = nowCard;
+
+    return result;
+  };
+
+  permu.forEach((_nowOrder) => {
+    nowOrder = _nowOrder;
+    const dfsResult = dfs({ y: r, x: c }, 0, 0);
+    result = dfsResult < result ? dfsResult : result;
+  });
+
+  return result;
+}
+
+function getCardTypeNumber(board) {
+  return new Set(Array.from(board.flat().filter((num) => num !== 0))).size;
+}
+
+function getCardLocation(board) {
+  const cardLocation = new Map();
+
+  board.forEach((row, i) => {
+    row.forEach((cell, j) => {
+      if (cell === 0) {
+        return;
+      }
+      const num = board[i][j];
+      cardLocation.has(num)
+        ? cardLocation.get(num).push({ y: i, x: j })
+        : cardLocation.set(num, [{ y: i, x: j }]);
+    });
+  });
+
+  return cardLocation;
+}
+
+function getPermu(cardTypeNumber, result, used, arr) {
+  if (arr.length === cardTypeNumber) {
+    result.push(arr);
+    return;
+  }
+  for (let i = 1; i <= cardTypeNumber; i++) {
+    if (used.has(i)) {
+      continue;
+    }
+    used.add(i);
+    getPermu(cardTypeNumber, result, used, [...arr, i]);
+    used.delete(i);
+  }
+  return result;
+}
+
+function isInBoard(y, x) {
+  return y >= 0 && y < 4 && x >= 0 && x < 4;
+}
+
+function getToGoalDist(board, origin, destination) {
+  const next = [ [-1, 0], [0, 1], [1, 0], [0, -1]]; // prettier-ignore
+  const visited = Array.from({ length: 4 }, () => Array(4).fill(false));
+  const q = [];
+
+  q.push([origin.y, origin.x, 0]);
+  visited[origin.y][origin.x] = true;
+
+  while (q.length) {
+    const [y, x, dist] = q.shift();
+
+    if (y === destination.y && x === destination.x) {
+      return dist;
+    }
+
+    for (const [yy, xx] of next) {
+      const [nyCtrl, nxCtrl] = getNextPosUsingCtrl(board, { y, x }, yy, xx);
+      if (!visited[nyCtrl][nxCtrl]) {
+        q.push([nyCtrl, nxCtrl, dist + 1]);
+        visited[nyCtrl][nxCtrl] = true;
+      }
+
+      const [ny, nx] = [yy + y, xx + x];
+      if (!isInBoard(ny, nx) || visited[ny][nx]) {
+        continue;
+      }
+      q.push([ny, nx, dist + 1]);
+      visited[ny][nx] = true;
+    }
+  }
+}
+
+function getNextPosUsingCtrl(board, nowPos, yy, xx) {
+  let { y, x } = nowPos;
+  let i = 1;
+  while (true) {
+    const [ny, nx] = [y + yy * i, x + xx * i];
+    if (!isInBoard(ny, nx)) break;
+    y = ny;
+    x = nx;
+    if (board[y][x] !== 0) break;
+  }
+  return [y, x];
+}
+
+const a = solution(
+  [
+    [1, 0, 0, 0],
+    [0, 0, 0, 0],
+    [0, 0, 1, 0],
+    [0, 0, 0, 0],
+  ],
+  0,
+  0
+);
+console.log(a);


### PR DESCRIPTION
# 네트워크
방문하지 않은곳만 방문해 bfs로 간단하게 풀이

# 카드 짝 맞추기
n이 매우 작기때문에 완전 탐색이 가능한 문제임.
그런데 dfs + bfs 모두 포함된 문제라 구현에 시간이 오래 걸렸음
제일 처음으로 할건 카드 순서를 구해주는 과정임.
시작 지점도 다르고 카드 위치도 다 다르기에 모든 경우를 구함

그 후 구해진 순서에 따라 dfs를 돌면서 bfs를 사용해 최단거리를 구해줌.
그런데 최단거리를 구할 때도 2가지 경우의 수가 존재함.
  1. 현재위치 -> pair1 -> pair2 의 경우
  2. 현재위치 -> pair2 -> pair1 의 경우

그래서 해당 두가지 경우에 대해 dfs로  후 더 짧은 거리를 구한 후
모든 경우의 수에 대해 최단거리를 구해서 리턴시킴.

# 순위 검색
50000 * 15 = 75만
info에  대해서 15개의 조합에 대해 map에 저장함.
key는 조합이름, value는 점수를 넣게됨.

그 후 dict에서 해당 값의 배열을 찾아서 이진탐색으로
해당 값 `이상`인 값을 찾음 그래서 lower bound를 적용하면됨
queries.forEach에서 해당 쿼리의 배열 길이가 0일 경우 예외처리 안해서 런타임 에러 떴음
!searchTarget 으로 예외처리 해서 풀게됨

# 징검다리 건너기
만약 숫자를 1씩 늘려서 탐색하면 n이 커서 무조건 시간초과가 난다고 생각했음.
어떤 값을 이진 탐색으로 찾아야 할지 고민을 했는데
0이 k가 이상이 되는 구간을 찾으면 사람수를 줄여서 찾아보고
찾지 못하면 사람수를 늘려서 최적의 사람 수를 구하는 방식으로 문제를 풀음. 