### PR TITLE
Week6: 박유현 문제풀이

### DIFF
--- a/yuhyun/Graph/가장 먼 노드.js
+++ b/yuhyun/Graph/가장 먼 노드.js
@@ -1,0 +1,59 @@
+function solution(n, edge) {
+  const start = 0;
+  const graph = createGraph(n, edge);
+  const distance = bfs(start, n, graph);
+
+  const maxDistance = Math.max(...distance);
+
+  return distance.filter((value) => value === maxDistance).length;
+}
+
+function createGraph(n, edge) {
+  const graph = Array.from(Array(n), () => []);
+  edge.forEach(([nodeA, nodeB]) => {
+    graph[nodeA - 1].push(nodeB - 1);
+    graph[nodeB - 1].push(nodeA - 1);
+  });
+  return graph;
+}
+
+function createQueue() {
+  let head = 0;
+  const queue = [];
+
+  return {
+    enqueue: (value) => queue.push(value),
+    dequeue: () => {
+      const value = queue[head];
+      head += 1;
+      return value;
+    },
+    isEmpty: () => queue.length === head,
+  };
+}
+
+function bfs(start, n, graph) {
+  const distance = Array(n).fill(Infinity);
+
+  const queue = createQueue();
+  queue.enqueue(start);
+
+  distance[start] = 0;
+
+  while (!queue.isEmpty()) {
+    const curNode = queue.dequeue();
+    const neighborhood = graph[curNode];
+    const nextDistance = distance[curNode] + 1;
+
+    neighborhood.forEach((nextNode) => {
+      if (distance[nextNode] <= nextDistance) {
+        return;
+      }
+
+      distance[nextNode] = nextDistance;
+      queue.enqueue(nextNode);
+    });
+  }
+
+  return distance;
+}

--- a/yuhyun/Graph/미로 탈출 명령어.js
+++ b/yuhyun/Graph/미로 탈출 명령어.js
@@ -1,0 +1,113 @@
+function solution(n, m, x, y, r, c, k) {
+  const direction = [
+    ["d", 1, 0],
+    ["l", 0, -1],
+    ["r", 0, 1],
+    ["u", -1, 0],
+  ];
+
+  const shortestPath = Array.from(Array(n), () =>
+    Array.from(Array(m), () => Array(k + 1).fill(""))
+  );
+
+  const bfs = (startR, startC) => {
+    const queue = new Queue();
+    queue.enqueue([startR, startC, 0]);
+
+    while (!queue.isEmpty()) {
+      const [curR, curC, length] = queue.dequeue();
+      const path = shortestPath[curR][curC][length];
+
+      const distance = calcDistance(curR, curC, r - 1, c - 1);
+      const remain = k - length;
+      if (distance > remain) {
+        continue;
+      }
+
+      if ((remain - distance) % 2 !== 0) {
+        continue;
+      }
+
+      if (length === k) {
+        continue;
+      }
+
+      const nextLength = length + 1;
+
+      for (let i = 0; i < direction.length; i++) {
+        const [dir, dr, dc] = direction[i];
+        const nextR = curR + dr;
+        const nextC = curC + dc;
+        if (outOfRange(nextR, nextC, n, m)) {
+          continue;
+        }
+
+        const nextPath = path + dir;
+        const nextShortestPath = shortestPath[nextR][nextC][nextLength];
+        if (nextShortestPath !== "" && nextShortestPath <= nextPath) {
+          continue;
+        }
+
+        shortestPath[nextR][nextC][nextLength] = nextPath;
+        queue.enqueue([nextR, nextC, nextLength]);
+      }
+    }
+  };
+
+  bfs(x - 1, y - 1);
+
+  return shortestPath[r - 1][c - 1][k] || "impossible";
+}
+
+class Node {
+  constructor(value) {
+    this.value = value;
+    this.next = null;
+  }
+}
+
+class Queue {
+  constructor() {
+    this.head = null;
+    this.tail = null;
+    this.length = 0;
+  }
+
+  enqueue(value) {
+    const newNode = new Node(value);
+    if (this.isEmpty()) {
+      this.head = this.tail = newNode;
+    } else {
+      this.tail.next = newNode;
+      this.tail = newNode;
+    }
+    this.length += 1;
+  }
+
+  dequeue() {
+    if (this.isEmpty()) {
+      return;
+    }
+
+    const value = this.head.value;
+    if (this.length === 1) {
+      this.head = this.tail = null;
+    } else {
+      this.head = this.head.next;
+    }
+    this.length -= 1;
+    return value;
+  }
+
+  isEmpty() {
+    return this.length === 0;
+  }
+}
+
+function outOfRange(r, c, R, C) {
+  return r < 0 || c < 0 || R <= r || C <= c;
+}
+
+function calcDistance(r1, c1, r2, c2) {
+  return Math.abs(r1 - r2) + Math.abs(c1 - c2);
+}

--- a/yuhyun/ShortestPath/택배 배달과 수거하기.js
+++ b/yuhyun/ShortestPath/택배 배달과 수거하기.js
@@ -1,0 +1,53 @@
+function solution(cap, n, deliveries, pickups) {
+  const deliveryAll = (deliveries) => {
+    let last = n - 1;
+    const distance = [];
+
+    while (true) {
+      const [start, end, nDeliveried] = delivery(last, cap, deliveries);
+      if (nDeliveried === 0) {
+        break;
+      }
+
+      distance.push(start + 1);
+      last = end;
+    }
+
+    return distance;
+  };
+
+  const delivery = (last, cap, deliveries) => {
+    let start = 0;
+    let end = last;
+    let nBox = 0;
+    for (; end >= 0; end -= 1) {
+      const curDelivery = deliveries[end];
+      if (curDelivery === 0) {
+        continue;
+      }
+
+      const nDeliveried = Math.min(cap - nBox, curDelivery);
+      if (start === 0) {
+        start = end;
+      }
+
+      deliveries[end] -= nDeliveried;
+      nBox += nDeliveried;
+
+      if (nBox === cap) {
+        break;
+      }
+    }
+    return [start, end, nBox];
+  };
+
+  const deliveryDistance = deliveryAll(deliveries);
+  const pickupDistance = deliveryAll(pickups);
+
+  let result = 0;
+  const maxLength = Math.max(deliveryDistance.length, pickupDistance.length);
+  for (let i = 0; i < maxLength; i += 1) {
+    result += Math.max(deliveryDistance[i] || 0, pickupDistance[i] || 0) * 2;
+  }
+  return result;
+}

--- a/yuhyun/ShortestPath/합승 택시 요금.js
+++ b/yuhyun/ShortestPath/합승 택시 요금.js
@@ -1,0 +1,45 @@
+function solution(n, s, a, b, fares) {
+  let min = Infinity;
+  const shortestDistance = floydWarshall(n, fares);
+
+  for (let via = 0; via < n; via++) {
+    const fare =
+      shortestDistance[s - 1][via] +
+      shortestDistance[via][a - 1] +
+      shortestDistance[via][b - 1];
+    min = Math.min(min, fare);
+  }
+
+  return min;
+}
+
+function floydWarshall(n, fares) {
+  const shortestDistance = Array.from(Array(n), () => Array(n).fill(Infinity));
+  fares.forEach(([c, d, f]) => {
+    shortestDistance[c - 1][d - 1] = shortestDistance[d - 1][c - 1] = f;
+  });
+
+  for (let i = 0; i < n; i++) {
+    shortestDistance[i][i] = 0;
+  }
+
+  for (let via = 0; via < n; via++) {
+    for (let start = 0; start < n; start++) {
+      for (let end = 0; end < n; end++) {
+        if (start === end) {
+          continue;
+        }
+
+        const curDistance =
+          shortestDistance[start][via] + shortestDistance[via][end];
+        if (shortestDistance[start][end] <= curDistance) {
+          continue;
+        }
+
+        shortestDistance[start][end] = curDistance;
+      }
+    }
+  }
+
+  return shortestDistance;
+}


### PR DESCRIPTION
## 가장 먼 노드
- bfs로 노드별 최단거리를 구한 뒤 가장 먼 노드의 갯수 세기

## 미로 탈출 명령어
- ❌ 실패 28.1 / 100.0
- 최적화 없이 왼쪽, 오른쪽, 위쪽, 아래쪽 방문 = 넉넉잡아 $4^k$ ($k$는 최대 2,500)이기 때문에 시간 초과남
- 어떻게 최적화하지? 거리별 사전 순으로 빠른 경로를 기록해야 하나? 메모리는 $n * m * 2k$ ($n$과 $m$의 최댓값은 50) 가능할 것 같아서 시도해 봤지만, heap out of memory
  - Linked list 로 구현한 큐여도 heap out of memory

<details>
  <summary>테스트 케이스 결과</summary>
 
|테스트 케이스   | 결과  |
|---|---|
|테스트 1 〉|통과 (19.02ms, 41.9MB)|
|테스트 2 〉|통과 (18.19ms, 41.9MB)|
|테스트 3 〉|통과 (3.34ms, 35.5MB)|
|테스트 4 〉|통과 (0.68ms, 33.7MB)|
|테스트 5 〉|통과 (0.69ms, 33.6MB)|
|테스트 6 〉|통과 (0.74ms, 33.6MB)|
|테스트 7 〉|통과 (0.73ms, 33.6MB)|
|테스트 8 〉|통과 (0.70ms, 33.6MB)|
|테스트 9 〉|실패 (signal: aborted (core dumped))|
|테스트 10 〉|실패 (signal: aborted (core dumped))|
|테스트 11 〉|실패 (signal: aborted (core dumped))|
|테스트 12 〉|실패 (signal: aborted (core dumped))|
|테스트 13 〉|실패 (signal: aborted (core dumped))|
|테스트 14 〉|실패 (signal: aborted (core dumped))|
|테스트 15 〉|실패 (signal: aborted (core dumped))|
|테스트 16 〉|실패 (signal: aborted (core dumped))|
|테스트 17 〉|실패 (signal: aborted (core dumped))|
|테스트 18 〉|실패 (signal: aborted (core dumped))|
|테스트 19 〉|실패 (signal: aborted (core dumped))|
|테스트 20 〉|실패 (signal: aborted (core dumped))|
|테스트 21 〉|실패 (signal: aborted (core dumped))|
|테스트 22 〉|실패 (signal: aborted (core dumped))|
|테스트 23 〉|실패 (signal: aborted (core dumped))|
|테스트 24 〉|실패 (signal: aborted (core dumped))|
|테스트 25 〉|실패 (signal: aborted (core dumped))|
|테스트 26 〉|실패 (signal: aborted (core dumped))|
|테스트 27 〉|실패 (signal: aborted (core dumped))|
|테스트 28 〉|실패 (signal: aborted (core dumped))|
|테스트 29 〉|실패 (signal: aborted (core dumped))|
|테스트 30 〉|실패 (signal: aborted (core dumped))|
|테스트 31 〉|통과 (56.94ms, 87.4MB)|
</details>

## 합승 택시 요금
- 플로이드 워셜 알고리즘으로 모든 노드에서 다른 모든 노드로의 최단 거리를 구하기
- 1부터 n까지 반복하며 택시 요금을 계산한 후 최솟값 반환

## 택배 배달과 수거하기
- 가장 마지막 집부터 배달 및 수거
- 배달을 위해 트럭이 움직일 때 이동한 거리를 배열로 기록, 수거를 위해 트럭이 움직일 때 이동한 거리를 배열로 기록한 후 배달 배열과 수거 배열의 요소 중 최댓값 * 2 의 누적합 반환