### PR TITLE
Week9: 박유현 문제풀이

### DIFF
--- a/yuhyun/Stack-Queue/무지의 먹방 라이브.js
+++ b/yuhyun/Stack-Queue/무지의 먹방 라이브.js
@@ -1,0 +1,50 @@
+function solution(food_times, k) {
+  const [remainFoodTimes, remainK] = clearFood(food_times, k);
+  return rotateFood(remainFoodTimes, remainK);
+}
+
+function clearFood(foodTimes, k) {
+  const FOOD_TIME = 0;
+  const FOOD = 1;
+
+  const descendingFoodTimes = foodTimes
+    .map((foodTime, food) => [foodTime, food + 1])
+    .sort((a, b) => b[FOOD_TIME] - a[FOOD_TIME] || b[FOOD] - a[FOOD]);
+
+  let round = 0;
+  while (descendingFoodTimes.length && k > 0) {
+    const remainFoodLength = descendingFoodTimes.length;
+
+    const [foodTime] = descendingFoodTimes.at(-1);
+
+    const remainFood = foodTime - round;
+    const clearCurFoodRoundTime = remainFoodLength * remainFood;
+
+    if (k < clearCurFoodRoundTime) {
+      break;
+    }
+
+    k -= clearCurFoodRoundTime;
+    round += remainFood;
+    while (descendingFoodTimes.at(-1)?.[FOOD_TIME] <= round) {
+      descendingFoodTimes.pop();
+    }
+  }
+  return [descendingFoodTimes, k];
+}
+
+function rotateFood(foodTimes, k) {
+  const FOOD = 1;
+
+  const remainFoodLength = foodTimes.length;
+  if (remainFoodLength === 0) {
+    return -1;
+  }
+
+  k = k % remainFoodLength;
+  const ascendingOrderFoodTimes = [...foodTimes].sort(
+    (a, b) => a[FOOD] - b[FOOD]
+  );
+
+  return ascendingOrderFoodTimes[k][FOOD];
+}

--- a/yuhyun/Stack-Queue/프로세스.js
+++ b/yuhyun/Stack-Queue/프로세스.js
@@ -1,0 +1,56 @@
+function solution(priorities, location) {
+  const PRIORITY = 0;
+  const ORDER = 1;
+
+  const ascendingPriorities = [...priorities].sort((a, b) => a - b);
+  const queue = new Queue();
+
+  priorities.map((priority, order) => queue.push([priority, order]));
+
+  let curOrder = 1;
+  while (ascendingPriorities.length) {
+    const maxPriority = ascendingPriorities.pop();
+
+    while (queue.peek()[PRIORITY] !== maxPriority) {
+      const process = queue.pop();
+      queue.push(process);
+    }
+
+    const executedProcess = queue.pop();
+    if (executedProcess[ORDER] === location) {
+      break;
+    }
+
+    curOrder += 1;
+  }
+
+  return curOrder;
+}
+
+class Queue {
+  constructor() {
+    this.queue = [];
+    this.head = 0;
+    this.size = 0;
+  }
+
+  push(value) {
+    this.queue.push(value);
+    this.size += 1;
+  }
+
+  pop() {
+    const value = this.queue[this.head];
+    this.head += 1;
+    this.size -= 1;
+    return value;
+  }
+
+  isEmpty() {
+    return this.size === this.head;
+  }
+
+  peek() {
+    return this.queue[this.head];
+  }
+}

--- a/yuhyun/String/[1차] 뉴스 클러스터링.js
+++ b/yuhyun/String/[1차] 뉴스 클러스터링.js
@@ -1,0 +1,69 @@
+function solution(str1, str2) {
+  const K = 65536;
+
+  const multiSet1 = toMultiSet(str1);
+  const multiSet2 = toMultiSet(str2);
+
+  const union = unionMultiSet(multiSet1, multiSet2);
+  const intersection = intersectionMultiSet(multiSet1, multiSet2);
+
+  const unionSize = countFrequencyMap(union);
+  const intersectionSize = countFrequencyMap(intersection);
+
+  return Math.floor((unionSize === 0 ? 1 : intersectionSize / unionSize) * K);
+}
+
+function toMultiSet(str) {
+  const multiSet = [];
+  for (let index = 0; index < str.length - 1; index += 1) {
+    const element = str.substring(index, index + 2).toLowerCase();
+    if (!/^[a-z]{2}$/.test(element)) continue;
+    multiSet.push(element);
+  }
+  return multiSet;
+}
+
+function unionMultiSet(setA, setB) {
+  const mapA = calcFrequency(setA);
+  const mapB = calcFrequency(setB);
+  const unionMap = new Map(mapA);
+
+  mapB.forEach((frequency, element) => {
+    if (unionMap.has(element) && unionMap.get(element) >= frequency) {
+      return;
+    }
+
+    unionMap.set(element, frequency);
+  });
+
+  return unionMap;
+}
+
+function intersectionMultiSet(setA, setB) {
+  const mapA = calcFrequency(setA);
+  const mapB = calcFrequency(setB);
+  const intersectionMap = new Map();
+
+  mapA.forEach((frequency, element) => {
+    if (!mapB.has(element)) return;
+    const min = Math.min(frequency, mapB.get(element));
+    intersectionMap.set(element, min);
+  });
+
+  return intersectionMap;
+}
+
+function calcFrequency(set) {
+  const map = new Map();
+  set.forEach((element) => {
+    const frequency = map.get(element) ?? 0;
+    map.set(element, frequency + 1);
+  });
+  return map;
+}
+
+function countFrequencyMap(frequencyMap) {
+  let cnt = 0;
+  frequencyMap.forEach((frequency) => (cnt += frequency));
+  return cnt;
+}

--- a/yuhyun/String/매칭 점수.js
+++ b/yuhyun/String/매칭 점수.js
@@ -1,0 +1,78 @@
+function solution(word, pages) {
+  const pageScoreMap = new Map(
+    pages.map((page, index) => {
+      const url = extractUrl(page);
+      const externalLinkArray = extractExternalLinkArray(page);
+      const wordCnt = countWord(word, page);
+
+      return [url, { index, externalLinkArray, baseScore: wordCnt }];
+    })
+  );
+
+  const pageMatchScoreArray = Array(pages.length).fill(0);
+  pageScoreMap.forEach(({ index, externalLinkArray, baseScore }, url) => {
+    pageMatchScoreArray[index] += baseScore;
+
+    externalLinkArray.forEach((externalLink) => {
+      if (!pageScoreMap.has(externalLink)) {
+        return;
+      }
+
+      const { index: externalLinkPageIndex } = pageScoreMap.get(externalLink);
+      pageMatchScoreArray[externalLinkPageIndex] +=
+        baseScore / externalLinkArray.length;
+    });
+  });
+
+  const maxMatchScore = Math.max(...pageMatchScoreArray);
+  return pageMatchScoreArray.findIndex(
+    (matchScore) => matchScore === maxMatchScore
+  );
+}
+
+function extractUrl(page) {
+  return /<meta property="og:url" content="(\S+)"/.exec(page)[1].trim();
+}
+
+function extractExternalLinkArray(page) {
+  return [...page.matchAll(/<a href="(\S+)">/g)].map(
+    (matchResult) => matchResult[1]
+  );
+}
+
+function countWord(word, page) {
+  const lowerWord = word.toLowerCase();
+  const alphabetRegex = /[a-z]{1}/i;
+
+  const bodyContent = extractBodyContent(page).toLowerCase();
+  const bodyContentOnlyEng = filterLinkTag(bodyContent).replaceAll(
+    /[^a-z]/g,
+    " "
+  );
+
+  return bodyContentOnlyEng
+    .split(/\s/)
+    .filter((curWord) => curWord === lowerWord).length;
+}
+
+function extractBodyContent(page) {
+  const BODY_START_TAG = "<body>";
+  const BODY_END_TAG = "</body>";
+
+  const bodyStartTagIndex = page.indexOf(BODY_START_TAG);
+  const bodyEndTagIndex = page.indexOf(BODY_END_TAG);
+
+  return page.substring(
+    bodyStartTagIndex + BODY_START_TAG.length,
+    bodyEndTagIndex
+  );
+}
+
+function filterLinkTag(page) {
+  const LINK_START_TAG_REGEX = /<a href=\"\S+">/g;
+  const LINK_END_TAG = "</a>";
+
+  return page
+    .replaceAll(LINK_START_TAG_REGEX, " ")
+    .replaceAll(LINK_END_TAG, " ");
+}

--- a/yuhyun/String/튜플.js
+++ b/yuhyun/String/튜플.js
@@ -1,0 +1,20 @@
+function solution(s) {
+  const array = JSON.parse(s.replaceAll("{", "[").replaceAll("}", "]"));
+  const ascendingLengthArray = array.sort((a, b) => a.length - b.length);
+
+  const set = new Set();
+  const tuple = [];
+
+  ascendingLengthArray.forEach((subArray) => {
+    subArray.forEach((element) => {
+      if (set.has(element)) {
+        return;
+      }
+
+      set.add(element);
+      tuple.push(element);
+    });
+  });
+
+  return tuple;
+}


### PR DESCRIPTION
## 프로세스
- 프로세스 우선순위를 오름차순으로 정렬한 배열과 큐로 풀이

## 무지의 먹방 라이브
- 효율성 테스트 제한 사항에서 시간 $k$는 $1 \leq k \leq 2 \times 10^{13}$ 이므로 $O(k)$ 알고리즘으로 못 풂
- 시간이 아닌 음식을 기준으로 섭취하면 $1 \leq$ `food_times.length` $\leq 2000$, $O(2000)$ 알고리즘으로 해결 가능
- 현재 회전판에 있는 음식 중 모두 먹는데 가장 적게 걸리는 음식을 차례대로 먹으면 됨
  - `food_times`를 음식을 모두 먹는데 필요한 시간을 기준으로 내림차순으로 정렬
- 테스트 케이스 19, 23 실패
	- 먹는 시간이 같은 음식이 있을 경우를 고려해야 함
	- 반례 `[3, 3], 6` 기대값 `-1`

## 뉴스 클러스터링
- 요구사항대로 풀면 됨

## 튜플
- 문자열에서 `{` > `[`, `}` > `]` 으로 치환한 후 `JSON.parse` 으로 배열로 변환
- 집합의 크기가 작은 순서로 정렬한 후 튜플 채워넣음

## 매칭 점수
- 웹페이지 url과 외부 링크는 정규 표현식으로 추출
- word 갯수는 body 태그 내 문자열 추출 > 외부 링크 제거 > 알파벳을 제외한 문자열 모두 공백으로 치환해서 계산함
- 키가 `url`이고 값이 `{ url, externalLinkArray, baseScore }`인 Map이랑 배열 이용해서 점수 계산함
- 처음에 50.0점 이길래 왜 틀렸는지 이해가 안 되서 찾아보니까 정규 표현식에서 `(.+)` 부분을 `(\S+)`으로 고쳐야 한다고 함. 고치니까 100.0점 됨;