### PR TITLE
Week9: 박정석 문제풀이

### DIFF
--- a/jeongseok/Stack-Queue/무지의 먹방 라이브.js
+++ b/jeongseok/Stack-Queue/무지의 먹방 라이브.js
@@ -1,0 +1,57 @@
+function solution(food_times, k) {
+  let arr = [];
+
+  let foods = 0;
+
+  food_times.map((ele, index) => {
+    arr.push({ index: index + 1, size: ele });
+    foods += ele;
+  });
+
+  if (foods <= k) {
+    return -1;
+  }
+
+  arr.sort((a, b) => {
+    return a.size - b.size;
+  });
+
+  let repeat = [];
+
+  for (let i = 0; i < arr.length; i++) {
+    if (i === 0) {
+      repeat.push(arr[i].size);
+    } else {
+      repeat.push(arr[i].size - arr[i - 1].size);
+    }
+  }
+
+  let remainIndex = 0;
+
+  for (let i = 0; i < repeat.length; i++) {
+    // 해당 음식을 이미 다 먹었다면
+    if (repeat[i].size === 0) {
+      arr[i].size = 0;
+      continue;
+    }
+
+    // 해당 음식이 0이 될때 까지 반복을 못돌리면
+    if (k - (repeat.length - i) * repeat[i] < 0) {
+      remainIndex = k;
+      break;
+    } else {
+      k = k - (repeat.length - i) * repeat[i];
+      arr[i].size = 0;
+    }
+  }
+
+  arr = arr.filter((ele) => {
+    return ele.size !== 0;
+  });
+
+  arr.sort((a, b) => {
+    return a.index - b.index;
+  });
+
+  return arr[remainIndex % arr.length].index;
+}

--- a/jeongseok/Stack-Queue/프로세스.js
+++ b/jeongseok/Stack-Queue/프로세스.js
@@ -1,0 +1,35 @@
+function solution(priorities, location) {
+  const arr = [];
+
+  for (let i = 0; i < priorities.length; i++) {
+    arr.push({
+      l: i,
+      p: priorities[i],
+    });
+  }
+
+  let startIndex = 1;
+
+  while (arr.length) {
+    let data = arr.shift();
+    let isExist = false;
+
+    for (let i = 0; i < arr.length; i++) {
+      if (data.p < arr[i].p) {
+        arr.push(data);
+        isExist = true;
+        break;
+      }
+    }
+
+    if (isExist) {
+      continue;
+    }
+
+    if (data.l === location) {
+      return startIndex;
+    } else {
+      startIndex++;
+    }
+  }
+}

--- a/jeongseok/String/[1차] 뉴스 클러스터링.js
+++ b/jeongseok/String/[1차] 뉴스 클러스터링.js
@@ -1,0 +1,40 @@
+function solution(str1, str2) {
+  let s1Arr = [];
+  let s2Arr = [];
+
+  for (let i = 0; i < str1.length - 1; i++) {
+    let test = str1[i] + str1[i + 1];
+    if (test.match(/[A-Z]{2}/gi)) {
+      s1Arr.push(test.toUpperCase());
+    }
+  }
+
+  for (let i = 0; i < str2.length - 1; i++) {
+    let test = str2[i] + str2[i + 1];
+    if (test.match(/[A-Z]{2}/gi)) {
+      s2Arr.push(test.toUpperCase());
+    }
+  }
+
+  let set = new Set([...s1Arr, ...s2Arr]);
+
+  let max = 0; // 합집합
+  let min = 0; // 교집합
+
+  set.forEach((ele) => {
+    let s1Filter = s1Arr.filter((idx) => idx === ele).length;
+    let s2Filter = s2Arr.filter((idx) => idx === ele).length;
+
+    max += Math.max(s1Filter, s2Filter);
+    min += Math.min(s1Filter, s2Filter);
+  });
+
+  let answer;
+  if (max === 0 && min === 0) {
+    answer = 65536;
+  } else {
+    answer = Math.floor((min / max) * 65536);
+  }
+
+  return answer;
+}

--- a/jeongseok/String/매칭 점수.js
+++ b/jeongseok/String/매칭 점수.js
@@ -1,0 +1,70 @@
+// 기본 점수 : 검색 단어 수
+// 외부 링크 수 : 외부로 링크 걸린 수
+// 링크 점수 : 링크 걸린 다른 페이지의 기본 점수 / 외부 링크 수의 총합
+// 매칭 점수 : 기본 점수 + 링크 점수
+
+function solution(word, pages) {
+  word = word.toLowerCase();
+
+  // 총 점수
+  let scoreArr = [];
+
+  // 이름 배열
+  let nameArr = [];
+
+  // 기본 점수 배열
+  let originScoreArr = [];
+
+  // 외부 링크 수 배열
+  let linkCountArr = [];
+
+  // 기본 점수 및 외부 링크 수 구하기
+  for (let i = 0; i < pages.length; i++) {
+    let url = pages[i].match(/<meta property="og:url" content=(\S+)\/>/)[0];
+    url = url.slice(33, url.length - 3);
+
+    nameArr.push(url);
+
+    let score = 0;
+
+    pages[i].split(/[^a-zA-Z]/).map((ele) => {
+      if (ele.toLowerCase() === word) {
+        score += 1;
+      }
+    });
+
+    originScoreArr.push(score);
+    scoreArr.push({ index: i, score });
+
+    // 외부 링크 수 구하기
+    let urlList = pages[i].match(/<a href=(\S+)">/g);
+
+    linkCountArr.push(urlList ? urlList.length : 0);
+  }
+
+  for (let i = 0; i < pages.length; i++) {
+    // 외부 링크 구하기
+    let urlList = pages[i].match(/<a href=(\S+)">/g);
+
+    let linkScore = 0;
+
+    urlList &&
+      urlList.map((url) => {
+        const curUrl = url.slice(9, url.length - 2);
+        const outLinkIndex = nameArr.findIndex((ele) => ele === curUrl);
+        if (outLinkIndex >= 0) {
+          scoreArr[outLinkIndex].score += originScoreArr[i] / linkCountArr[i];
+        }
+      });
+  }
+
+  scoreArr.sort((a, b) => {
+    if (a.score === b.score) {
+      return a.index - b.index;
+    } else {
+      return b.score - a.score;
+    }
+  });
+
+  return scoreArr[0].index;
+}

--- a/jeongseok/String/튜플.js
+++ b/jeongseok/String/튜플.js
@@ -1,0 +1,19 @@
+function solution(s) {
+  let sCopy = s
+    .slice(2, -2)
+    .split("},{")
+    .map((val) => val.split(","))
+    .sort((a, b) => a.length - b.length);
+
+  let set = new Set();
+
+  sCopy.forEach((val) => val.forEach((ele) => set.add(ele)));
+
+  let answer = [];
+
+  for (val of set) {
+    answer.push(+val);
+  }
+
+  return answer;
+}


### PR DESCRIPTION
# 프로세스

# 무지의 먹방 라이브
배열을 하나씩 돌면서 반복하면 무조건 시간 초과가 발생함
=> 다른 방법을 생각해야함.

[4,2,1,3] 이 있다고 가정

1. 새로운 배열을 만드는데 배열에는 요소의 index, 음식 크기를 넣는다.

ex) 
[
  { index: 1, size: 4 },
  { index: 2, size: 2 },
  { index: 3, size: 1 },
  { index: 4, size: 3 }
]

1-1. 그 후 총 음식의 양보다 k가 크면 먹을 게 없으므로 -1을 return.
1-2. 그게 아니라면 음식의 크기 순으로 오름차순 정렬 함

2. 반복 횟수를 알 수 있도록 repeat 배열을 만든다.
만약 음식의 크기가 [1,2,3] 일 때 음식 섭취를 해보면 아래와 같이 된다.
0 2 3 => 0 1 3 => 0 1 2 => 0 0 2 => 0 0 1 => 0 0 0 이다.

가장 앞의 요소가 1이니깐 해당 요소를 다 먹으면 나머지 모든 요소도 1만큼 먹었을 것이다.
[1,2,3] => [0,1,2] 가 된다.

만약 [2,3,4,4,5] 라면 가장 앞의 요소를 다먹으려면 2번 반복해서 나머지 모든 요소도 2만큼 먹어야한다.
[2,3,4,4,5] => [0,1,2,2,3]

그러면 첫 번째 음식은 2번 반복하면 다 먹는다.
두 번째 음식은 이제 원래 음식의 양 3에서 2번만큼 반복했으므로 1이 남는다.

따라서 1만큼 더 반복하면 두 번째 음식은 다 먹는다.

이런식으로 1번에서 만든 배열을 반복문 돌면서 현재 음식의 크기 - (현재 음식 - 1)의 크기를 repeat 배열에 넣는다.


3. 이제 해당 음식을 다 먹으려면 몇번 반복해야하는지 알 수 있으니 음식을 먹는다.
만약,  repeat 배열이 [2,1,1,4,5] 라면 첫 번째 음식 다먹으려면 2번 반복, 두 번째 음식을 다먹으려면 1번 반복해야한다.

따라서 k에서 repeat 배열의 크기 * 해당 요소의 크기만큼 뺐을 때 k가 0보다 크거나 같다면 해당 음식을 다 먹을 수 있다.
하지만 repeat에서 [2,1,1,4,5] 에서 첫 번째 음식을 다 먹으면 [0,1,1,4,5]가 될 것이다. 그럼 첫 번째 음식은 다먹었으니 이제는 1번 반복에 5회 음식 섭취가 아니라4회 음식 섭취 이므로
k -repeat 배열의 크기 * 해당 요소의 크기가 아니라 `k-(repeat 배열의 크기-i) * 해당 요소의 크기`를 한다.

그 후 먹었음을 표시하기 위해 arr의 음식 크기를 0으로 만든다.

그리고 음식이 0인 요소를 제외하고 새 배열을 만들고 새배열[남은 음식 크기 % 새배열 크기]의 index가 k이후 먹는 음식의 index가 된다. 

# 뉴스 클러스터링
지문이 길고 복잡해서 그냥 요구사항을 잘 지켜서 풀었음

# 튜플
가장 앞뒤 괄호를 없애고  `},{`를 기준으로 split을 함
그러면 [ '2', '2,1', '2,1,3', '2,1,3,4' ] 이런식의 배열이 형성 되는데 각 요소를 ,를 기준으로 나누고 각 배열 요소의 원소 갯수로 정렬 함

그리고 Set에 하나씩 넣으면 됨

# 매칭 점수
정규식을 잘 쓰면 됨

처음에 .*를 했는데 계속 실패하길래 찾아보니깐 \S+로 하면 된다길래 바꾸니깐 통과했음

\S+는 공백이 아닌 문자만 가능하고 .*는 공백이 가능해서 그렇다.



