### PR TITLE
Week10: 윤채현 문제풀이

### DIFF
--- a/chaehyun/Hash/베스트 앨범.js
+++ b/chaehyun/Hash/베스트 앨범.js
@@ -1,0 +1,49 @@
+function solution(genres, plays) {
+  let genre = new Map();
+  let cnt = {};
+
+  genres.forEach((ele, idx) => {
+    genre.set(idx, [ele, plays[idx]]);
+  });
+
+  genre.forEach((item) => {
+    cnt[item[0]] = cnt[item[0]] ? cnt[item[0]] + item[1] : item[1];
+  });
+
+  let temp = [...genre.entries()].map((ele) => [
+    ...ele[1],
+    cnt[ele[1][0]],
+    ele[0],
+  ]);
+
+  temp.sort((a, b) => {
+    if (a[2] > b[2]) {
+      return -1;
+    } else if (b[2] > a[2]) {
+      return 1;
+    } else {
+      if (a[0] === b[0]) {
+        if (a[1] !== b[1]) return b[1] - a[1];
+        else return a[3] - b[3];
+      }
+    }
+    return 0;
+  });
+
+  let curCnt = 0;
+  let prevGenre = "";
+  const answer = [];
+
+  temp.forEach((item, idx) => {
+    if (curCnt !== 2 && item[0] !== prevGenre) {
+      answer.push(item[3]);
+      curCnt++;
+    }
+    if (curCnt === 2) {
+      prevGenre = temp[idx - 1][0];
+      curCnt = 0;
+    }
+  });
+
+  return answer;
+}

--- a/chaehyun/Hash/의상.js
+++ b/chaehyun/Hash/의상.js
@@ -1,0 +1,18 @@
+function solution(clothes) {
+  var answer = 1;
+  const map = new Map();
+
+  clothes.forEach((item) => {
+    const category = item[1];
+    map.set(item[1], map.get(category) ? map.get(category) + 1 : 1);
+  });
+
+  const newArr = [...map];
+
+  newArr.forEach((ele) => {
+    answer = answer * (ele[1] + 1);
+  });
+
+  answer -= 1;
+  return answer;
+}

--- a/chaehyun/Hash/전화번호 목록.js
+++ b/chaehyun/Hash/전화번호 목록.js
@@ -1,0 +1,36 @@
+// 1트 효율성 2개 시간초과 91.7점
+
+function solution(phone_book) {
+  phone_book = phone_book.sort();
+
+  for (let i = 0; i < phone_book.length; i++) {
+    const isDuplicate = phone_book.some((ele, index) => {
+      if (index !== i && ele.substr(0, phone_book[i].length) === phone_book[i])
+        return true;
+      return false;
+    });
+
+    if (isDuplicate) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+// 2트 100점
+
+function solution(phone_book) {
+  phone_book = phone_book.sort();
+
+  for (let i = 0; i < phone_book.length - 1; i++) {
+    const isDuplicate =
+      phone_book[i + 1].substr(0, phone_book[i].length) === phone_book[i];
+
+    if (isDuplicate) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/chaehyun/Tree/양과 늑대.js
+++ b/chaehyun/Tree/양과 늑대.js
@@ -1,0 +1,27 @@
+function solution(info, edges) {
+  var answer = 0;
+  let tree = Array.from({ length: info.length }, () => []);
+  edges.forEach(([parent, child]) => {
+    tree[parent].push(child);
+  });
+
+  function dfs(currentNode, wolf, sheep, possibleNodes) {
+    answer = Math.max(sheep, answer);
+
+    if (wolf >= sheep) {
+      return;
+    }
+    possibleNodes = [...possibleNodes, ...tree[currentNode]];
+    possibleNodes.splice(possibleNodes.indexOf(currentNode), 1);
+
+    for (const nextNode of possibleNodes) {
+      if (info[nextNode]) {
+        dfs(nextNode, wolf + 1, sheep, possibleNodes);
+      } else {
+        dfs(nextNode, wolf, sheep + 1, possibleNodes);
+      }
+    }
+  }
+  dfs(0, 0, 1, [0]);
+  return answer;
+}

--- a/chaehyun/Tree/표현 가능한 이진 트리.js
+++ b/chaehyun/Tree/표현 가능한 이진 트리.js
@@ -1,0 +1,37 @@
+function solution(numbers) {
+  var answer = [];
+
+  for (const num of numbers) {
+    let binary = num.toString(2);
+    let cnt = nodeCount(binary);
+    binary = binary.padStart(cnt, "0");
+    answer.push(checkTree(binary) ? 1 : 0);
+  }
+
+  return answer;
+}
+
+function nodeCount(binary) {
+  let depth = 0;
+  let cnt = 0;
+  while (binary.length > cnt) {
+    cnt += 2 ** depth;
+    depth += 1;
+  }
+  return cnt;
+}
+
+function checkTree(binary) {
+  if (!binary.length) {
+    return true;
+  }
+  const parentNode = Math.floor(binary.length / 2);
+  if (binary[parentNode] === "0") {
+    for (let i = 0; i < binary.length; i++) {
+      if (binary[i] === "1") return false;
+    }
+  }
+  let leftTree = binary.slice(0, parentNode);
+  let rightTree = binary.slice(parentNode + 1);
+  return checkTree(leftTree) && checkTree(rightTree);
+}


### PR DESCRIPTION
## 표현 가능한 이진트리
이진수로 바꿔서 품
주어진 2진수의 길이에 따라서 해당 이진 트리의 노드 개수를 계산하고 이진수의 길이보다 큰 노드 개수 찾을 때까지 깊이 증가시키면서 노드 개수 계산
이진 트리의 조건을 만족하는지 재귀적으로 확인해서 풀 수 있었음

## 양과 늑대
여러번 시도해봤는데 dfs로 풀다가 양과 늑대가 같을 때를 어떻게 처리해야할 지 모르겠어서(코드는 간단한데 접근이 너무 어려웟음😭) 구글링해서 품 이해 완료
일단 tree 배열에 노드들의 정보를 저장하고
dfs로 재귀 돌면서 가장 큰 양의 개수를 answer에 누적해줌
그리고 다음으로 돌 수 있는 노드들을 순차적으로 dfs 재귀 돌려주면 풀 수 있음

## 베스트 앨범
각 노래의 정보를 genre라는 Map 자료구조에 저장하고, 장르별로 누적 플레이 수를 cnt 객체에 계산함. 
그리고 장르, 플레이 수, 누적 플레이 수, 인덱스 정보를 포함하는 2차원 배열 temp를 만들고 정렬한 다음 정렬된 배열에서 각 장르별로 두 개의 노래 인덱스를 추출해서 반환하는걸로 품

## 의상
각 의상 종류의 의상 수에 1을 더해 모두 곱한 다음 모든 종류에서 의상을 선택하지 않은 경우의 수를 빼서 풀었음

## 전화번호 목록
처음에는 그냥 some 고차함수로 체크해서 간단하게 풀어봄 정확도는 맞는데, 효율성 테스트 2개에서 시간초과남
정렬하면 된다고 힌트얻어서 정렬 한 다음 어짜피 접두사만 체크하니 다음것만 검사해도 된다는걸 깨닫고 풀이 완료

+ IDE로 옮기고 알게됐는데 `substr`이 deprecated 되었다고함. `substring` 쓰면 되는듯