### PR TITLE
Week11: 박정석 문제풀이

### DIFF
--- a/jeongseok/BruteForce/자물쇠와 열쇠.js
+++ b/jeongseok/BruteForce/자물쇠와 열쇠.js
@@ -1,0 +1,62 @@
+function turn(key) {
+  const turnArr = Array.from(Array(key.length), () => Array(key.length).fill(0));
+
+  for (let i = 0; i < key.length; i++) {
+    for (let j = 0; j < key.length; j++) {
+      turnArr[i][j] = key[key.length - 1 - j][i];
+    }
+  }
+
+  return turnArr;
+}
+
+function solution(key, lock) {
+  const len = lock.length + key.length * 2 - 2;
+
+  const arr = Array.from(Array(len), () => Array(len).fill(0));
+
+  for (let i = key.length - 1; i < len - key.length + 1; i++) {
+    for (let j = key.length - 1; j < len - key.length + 1; j++) {
+      arr[i][j] = lock[i - key.length + 1][j - key.length + 1];
+    }
+  }
+
+  // 모든 key 경우의 수 구하기
+  let keyArr = [key.map((v) => [...v])];
+  for (let i = 0; i < 3; i++) {
+    keyArr.push(turn(keyArr[keyArr.length - 1]));
+  }
+
+  for (let i = 0; i < 4; i++) {
+    const targetKeyArr = keyArr[i];
+
+    // 모든 경우 탐색
+    for (let j = 0; j < key.length + lock.length - 1; j++) {
+      for (let k = 0; k < key.length + lock.length - 1; k++) {
+        let copyArr = arr.map((v) => [...v]);
+
+        for (let y = 0; y < key.length; y++) {
+          for (let x = 0; x < key.length; x++) {
+            copyArr[j + y][k + x] += targetKeyArr[y][x];
+          }
+        }
+
+        let flag = true;
+
+        for (let ii = key.length - 1; ii < copyArr.length - key.length + 1; ii++) {
+          for (let jj = key.length - 1; jj < copyArr.length - key.length + 1; jj++) {
+            if (copyArr[ii][jj] !== 1) {
+              flag = false;
+            }
+          }
+        }
+
+        if (flag) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}

--- a/jeongseok/BruteForce/카펫.js
+++ b/jeongseok/BruteForce/카펫.js
@@ -1,0 +1,17 @@
+// 가로 >= 세로
+function solution(brown, yellow) {
+  let yellowHeight = 1;
+  while (1) {
+    if (yellow % yellowHeight === 0) {
+      let brownCount = (yellow / yellowHeight) * 2 + yellowHeight * 2 + 4;
+
+      if (brownCount === brown) {
+        break;
+      }
+    }
+
+    yellowHeight++;
+  }
+
+  return [yellow / yellowHeight + 2, yellowHeight + 2];
+}

--- a/jeongseok/BruteForce/파괴되지 않은 건물.js
+++ b/jeongseok/BruteForce/파괴되지 않은 건물.js
@@ -1,0 +1,39 @@
+function solution(board, skill) {
+  let attackMap = new Map();
+
+  for (let i = 0; i < skill.length; i++) {
+    const [type, r1, c1, r2, c2, degree] = skill[i];
+
+    let condition = String(r1) + "a" + String(c1) + "a" + String(r2) + "a" + String(c2);
+
+    let attackCondition = type === 1 ? -degree : degree;
+
+    if (attackMap.has(condition)) {
+      attackMap.set(condition, attackMap.get(condition) + attackCondition);
+    } else {
+      attackMap.set(condition, attackCondition);
+    }
+  }
+
+  for (let [key, value] of attackMap) {
+    const [r1, c1, r2, c2] = key.split("a").map(Number);
+
+    for (let i = r1; i < r2 + 1; i++) {
+      for (let j = c1; j < c2 + 1; j++) {
+        board[i][j] += value;
+      }
+    }
+  }
+
+  let answer = 0;
+
+  for (let i = 0; i < board.length; i++) {
+    for (let j = 0; j < board[0].length; j++) {
+      if (board[i][j] > 0) {
+        answer += 1;
+      }
+    }
+  }
+
+  return answer;
+}

--- a/jeongseok/Heap/이중우선순위큐.js
+++ b/jeongseok/Heap/이중우선순위큐.js
@@ -1,0 +1,120 @@
+function solution(operations) {
+  const minHeap = new Heap((a, b) => a - b);
+  const maxHeap = new Heap((a, b) => b - a);
+
+  let insertNumber = 0;
+
+  for (let i = 0; i < operations.length; i++) {
+    const [c, n] = operations[i].split(" ");
+
+    if (insertNumber === 0) {
+      minHeap.heap = [];
+      maxHeap.heap = [];
+    }
+
+    if (c === "I") {
+      maxHeap.push(Number(n));
+      minHeap.push(Number(n));
+      insertNumber++;
+    } else {
+      if (insertNumber > 0) {
+        insertNumber--;
+        Number(n) >= 0 ? maxHeap.pop() : minHeap.pop();
+      }
+    }
+  }
+
+  return insertNumber > 0 ? [maxHeap.pop(), minHeap.pop()] : [0, 0];
+}
+
+class Heap {
+  constructor(compareFn) {
+    this.compareFn = compareFn;
+    this.heap = [];
+  }
+
+  getLeftChildIndex(parentIndex) {
+    return parentIndex * 2 + 1;
+  }
+
+  getRightChildIndex(parentIndex) {
+    return parentIndex * 2 + 2;
+  }
+
+  getParentIndex(childIndex) {
+    return Math.floor((childIndex - 1) / 2);
+  }
+
+  hasLeftChild(parentIndex) {
+    return this.getLeftChildIndex(parentIndex) < this.heap.length;
+  }
+
+  hasRightChild(parentIndex) {
+    return this.getRightChildIndex(parentIndex) < this.heap.length;
+  }
+
+  hasParent(childIndex) {
+    return 0 <= this.getParentIndex(childIndex);
+  }
+
+  push(value) {
+    this.heap.push(value);
+    this.heapifyUp();
+  }
+
+  pop() {
+    if (this.size() === 0) {
+      return;
+    }
+
+    if (this.size() <= 1) {
+      return this.heap.pop();
+    }
+
+    const value = this.heap[0];
+    this.heap[0] = this.heap.pop();
+    this.heapifyDown();
+    return value;
+  }
+
+  top() {
+    return this.heap[0];
+  }
+
+  heapifyUp() {
+    let cur = this.size() - 1;
+    while (this.hasParent(cur) && this.compareFn(this.heap[cur], this.heap[this.getParentIndex(cur)]) < 0) {
+      const next = this.getParentIndex(cur);
+      this.swap(cur, next);
+      cur = next;
+    }
+  }
+
+  heapifyDown() {
+    let cur = 0;
+    while (this.hasLeftChild(cur)) {
+      const nextIsRight = this.hasRightChild(cur) && this.compareFn(this.heap[this.getRightChildIndex(cur)], this.heap[this.getLeftChildIndex(cur)]) < 0;
+
+      const next = nextIsRight ? this.getRightChildIndex(cur) : this.getLeftChildIndex(cur);
+
+      if (this.compareFn(this.heap[cur], this.heap[next]) <= 0) {
+        break;
+      }
+
+      this.swap(cur, next);
+      cur = next;
+    }
+  }
+
+  swap(a, b) {
+    [this.heap[a], this.heap[b]] = [this.heap[b], this.heap[a]];
+  }
+
+  isEmpty() {
+    return this.heap.length === 0;
+  }
+
+  size() {
+    return this.heap.length;
+  }
+}


### PR DESCRIPTION
# 이중우선순위큐
최대힙과 최소힙을 하나씩 만들어서 최대값빼는거면 최대힙에서 빼고 최소값빼는 거면 최소힙에서 뺀다.
그 이후에 넣은 횟수 - 뺀 횟수가 0이라면 모든게 빠진거니깐 [0,0]을 return하고 그게 아니면 최대힙에서 하나 최소힙에서 하나 뺀다.


# 카펫
노란색의 세로 길이가 1일때부터 완탐

# 파괴되지 않은 건물
효율성에서 50% 틀림, 추후에 누적합으로 고쳐야할듯

## 실패한 나의 풀이
실시간으로 모든 좌표를 업데이트하면 반드시 시간초과이므로 데미지 Map을 만든다.
이 때 key는 type+r1+c1+r2+c2이고 value는 degree다.
예를 들어 type = 1, r1 = 0, c1 = 0, r2 = 3, c2 = 5, degree = 4라면 key는 '10035'가 된다. value는 -4가 된다.

하지만 key를 단순히 type+r1+c1+r2+c2로 하면 문제가 있다.

예를 들어 (0,1)에서 (11,3)까지 -2 데미지면 key가 `011132`다. 하지만 (0,11)에서 (1,3)까지 -2 데미지도 key가 `011132`다. 따라서 각 좌표사이 a를 넣어서 원치않은 중복을 제거 한다.

즉, (0,1)에서 (11,3)까지는 `0a1a11a3a`고 (0,11)에서 (1,3)까지는 `0a11a1a3a`로 한다.


그렇게 해서 skill의 길이만큼 반복하면 Map이 만들어진다. 그리고 Map을 반복하면서 진짜 데미지를 준다.

잘 생각해보면 Map객체의 요소의 최악의 경우에는 0,0부터 100,100까지 데미지를 줘서 10,000번을 업데이트하는 것이지만  해당 경우는 Map에 딱 1개밖에 없다. 나머지는 반드시 그보다 작을 것이다.

하지만 틀렸는데 아마, 내 생각보다 100 x 100에서 만들 수 있는 직사각형의 갯수가 매우 많은 것 같다.(정확히 몇개인지는 수학과가 아니라서 포기, 누군가가 계산해줬으면 좋겠다.)




# 자물쇠와 열쇠
전체 배열을 확장한다. 배열의 길이는 자물쇠 길이 + (열쇠 길이 * 2) - 2다. 이렇게 만든 이유는 회전만 신경쓰고 상하좌우 이동은 신경 쓰지 않기 위해

그리고 00부터 열쇠가 가능한 마지막 좌표까지 반복해서 모든 좌표가 1인 것이 있으면 true를 아니면 false를 반환

