### PR TITLE
Week12: 박유현 문제풀이

### DIFF
--- a/yuhyun/BinarySearch/가사 검색.js
+++ b/yuhyun/BinarySearch/가사 검색.js
@@ -1,0 +1,70 @@
+function solution(words, queries) {
+  const WILDCARD = "?";
+
+  const reversedWords = words.map(reverse);
+  reversedWords.sort();
+  words.sort();
+
+  const cache = new Map();
+  return queries.map((query) => {
+    if (cache.has(query)) return cache.get(query);
+
+    const [curWords, curQuery] = query.endsWith(WILDCARD)
+      ? [words, query]
+      : [reversedWords, reverse(query)];
+    const start = lowerBound(curQuery, curWords, compare);
+    const end = upperBound(curQuery, curWords, compare);
+    const result = curWords
+      .slice(start, end)
+      .filter((word) => word.length === curQuery.length).length;
+
+    cache.set(query, result);
+    return result;
+  });
+}
+
+function reverse(word) {
+  return [...word].reverse().join("");
+}
+
+function compare(word, query) {
+  const WILDCARD = "?";
+
+  const shortLength = word.length < query.length ? word.length : query.length;
+  for (let index = 0; index < shortLength; index += 1) {
+    const wordChar = word[index];
+    const queryChar = query[index];
+
+    if (queryChar === WILDCARD || queryChar === wordChar) continue;
+    return wordChar.charCodeAt(0) - queryChar.charCodeAt(0);
+  }
+  return 0;
+}
+
+function lowerBound(query, words, compare) {
+  let left = -1;
+  let right = words.length;
+  while (left + 1 < right) {
+    const mid = Math.floor((left + right) / 2);
+    if (compare(words[mid], query) < 0) {
+      left = mid;
+      continue;
+    }
+    right = mid;
+  }
+  return right;
+}
+
+function upperBound(query, words) {
+  let left = -1;
+  let right = words.length;
+  while (left + 1 < right) {
+    const mid = Math.floor((left + right) / 2);
+    if (compare(words[mid], query) > 0) {
+      right = mid;
+      continue;
+    }
+    left = mid;
+  }
+  return right;
+}

--- a/yuhyun/DFS-BFS/동굴 탐험.js
+++ b/yuhyun/DFS-BFS/동굴 탐험.js
@@ -1,0 +1,49 @@
+function solution(n, path, order) {
+  const ENTER = 0;
+
+  const graph = Array.from(Array(n), () => []);
+  path.forEach(([a, b]) => {
+    graph[a].push(b);
+    graph[b].push(a);
+  });
+
+  const indegree = Array(n).fill(0);
+  const outNodes = Array.from(Array(n), () => []);
+  order.forEach(([before, after]) => {
+    indegree[after] += 1;
+    outNodes[before].push(after);
+  });
+
+  return indegree[ENTER] !== 0
+    ? false
+    : traverse(ENTER, graph, indegree, outNodes).every((v) => v);
+}
+
+function traverse(start, graph, indegree, outNodes) {
+  const visited = Array(indegree.length).fill(false);
+  const stack = [start];
+  const reachable = new Set();
+
+  while (stack.length) {
+    const cur = stack.pop();
+    visited[cur] = true;
+
+    outNodes[cur].forEach((after) => {
+      indegree[after] -= 1;
+      if (indegree[after] === 0 && reachable.has(after)) {
+        reachable.delete(after);
+        stack.push(after);
+      }
+    });
+
+    graph[cur].forEach((next) => {
+      if (visited[next]) return;
+      if (indegree[next] !== 0) {
+        reachable.add(next);
+        return;
+      }
+      stack.push(next);
+    });
+  }
+  return visited;
+}

--- a/yuhyun/DFS-BFS/불량 사용자.js
+++ b/yuhyun/DFS-BFS/불량 사용자.js
@@ -1,0 +1,28 @@
+function solution(user_id, banned_id) {
+  const bannedLength = banned_id.length;
+  const cases = new Set();
+
+  const dfs = (bannedBit, bannedIndex) => {
+    if (bannedIndex === bannedLength) {
+      cases.add(bannedBit);
+      return;
+    }
+
+    const maskedId = banned_id[bannedIndex];
+    user_id.forEach((id, index) => {
+      if (bannedBit & (1 << index) || !isBanned(id, maskedId)) return;
+      dfs(bannedBit | (1 << index), bannedIndex + 1);
+    });
+  };
+
+  dfs(0, 0);
+  return cases.size;
+}
+
+function isBanned(id, maskedId) {
+  const MASK = "*";
+  if (id.length !== maskedId.length) return false;
+  return [...maskedId].every((char, index) =>
+    char === MASK ? true : char === id[index]
+  );
+}

--- a/yuhyun/DP/매출 하락 최소화.js
+++ b/yuhyun/DP/매출 하락 최소화.js
@@ -1,0 +1,41 @@
+function solution(sales, links) {
+  const CEO = 0;
+  const tree = createTree(links);
+  return Math.min(...dfs(CEO, tree, sales));
+}
+
+function dfs(root, tree, sales) {
+  const children = tree[root];
+  const sale = sales[root];
+
+  const leafNode = children.length === 0;
+  if (leafNode) {
+    return [0, sale];
+  }
+
+  const subtreeDp = [];
+  children.forEach((child) => subtreeDp.push(dfs(child, tree, sales)));
+
+  const withRoot = [
+    sale,
+    ...subtreeDp.map((subResults) => Math.min(...subResults)),
+  ].reduce((acc, cur) => acc + cur, 0);
+
+  const withoutRoot = subtreeDp.map(([subWithoutRoot, subWithRoot], index) => {
+    const min = Math.min(subWithoutRoot, subWithRoot);
+    return withRoot - sale - min + subWithRoot;
+  });
+
+  return [Math.min(...withoutRoot), withRoot];
+}
+
+function createTree(links) {
+  const PADDING = 1;
+
+  const nNode = links.length + 1;
+  const result = Array.from(Array(nNode), () => []);
+  links.forEach(([parent, child]) =>
+    result[parent - PADDING].push(child - PADDING)
+  );
+  return result;
+}

--- a/yuhyun/DP/코딩 테스트 공부.js
+++ b/yuhyun/DP/코딩 테스트 공부.js
@@ -1,0 +1,42 @@
+function solution(alp, cop, problems) {
+  let maxAlp = alp;
+  let maxCop = cop;
+  let maxAlpRwd = 0;
+  let maxCopRwd = 0;
+
+  problems.forEach(([reqAlp, reqCop, rwdAlp, rwdCop]) => {
+    if (maxAlp < reqAlp) maxAlp = reqAlp;
+    if (maxCop < reqCop) maxCop = reqCop;
+    if (maxAlpRwd < rwdAlp) maxAlpRwd = rwdAlp;
+    if (maxCopRwd < rwdCop) maxCopRwd = rwdCop;
+  });
+
+  const ROW = maxAlp + maxAlpRwd + 1;
+  const COL = maxCop + maxCopRwd + 1;
+
+  const dp = Array.from(Array(ROW), () => Array(COL).fill(Infinity));
+  dp[alp][cop] = 0;
+
+  problems.push([0, 0, 1, 0, 1], [0, 0, 0, 1, 1]);
+
+  let result = Infinity;
+  for (let row = alp; row < ROW; row += 1) {
+    for (let col = cop; col < COL; col += 1) {
+      problems.forEach(([reqAlp, reqCop, rwdAlp, rwdCop, cost]) => {
+        const beforeRow = row - rwdAlp < alp ? alp : row - rwdAlp;
+        const beforeCol = col - rwdCop < cop ? cop : col - rwdCop;
+        const solvable = reqAlp <= beforeRow && reqCop <= beforeCol;
+        const newCost = dp[beforeRow][beforeCol] + cost;
+        if (solvable && newCost < dp[row][col]) {
+          dp[row][col] = newCost;
+        }
+      });
+
+      if (row >= maxAlp && col >= maxCop && result > dp[row][col]) {
+        result = dp[row][col];
+      }
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## 매출 하락 최소화
- DFS로 트리를 탐색하며 bottom-up으로 `[루트를 포함하지 않은 최소 매출, 루트를 포함한 최소 매출]` 를 계산하여 풂

## ❌ 코딩 테스트 공부
- `dp[i][j]`는 알고력 i와 코딩력 j이 될 때까지 걸리는 최소 시간
- `dp[i][j]`는 문제별로 문제를 풀었을 때 알고력 i와 코딩력 j가 되는 최소 시간에서 문제를 푸는 시간을 더해 갱신
	- `dp[i][j] = Math.min(dp[i - 문제 1 보상 알고력][j - 문제 1 보상 알고력] + 문제 1 소요 시간, ...)`
- 반례 (질문하기 봄)
	- 초기 알고력이나 코딩력이 모든 문제를 푸는데 필요한 최대 알고력이나 코딩력보다 높은 경우
	- 모든 문제를 푸는데 필요한 최대 알고력과 코딩력보다 더 높은 알고력과 코딩력이 될 때까지 걸리는 최소 시간이 적은 경우
- 효율성 10번 테스트 시간 초과 엔딩;

## 동굴 탐험
- BFS + 위상 정렬
- 반례
	- 30번 테스트 0번 방보다 먼저 방문해야 할 방이 있는 경우

## 불량 사용자
- DFS + 비트 연산자

## 가사 검색
- lowerBound, upperBound
- 와일드카드가 검색 키워드의 접두사인 경우
	- 가사 단어와 검색 키워드를 뒤집어서 정렬된 배열로 만든 후 lowerBound, upperBound 수행
- 캐싱 적용해야 효율성 3번 테스트 케이스 시간 초과 안 됨
