### PR TITLE
Week13: 박유현 문제풀이

### DIFF
--- a/yuhyun/Implementation/기둥과 보 설치.js
+++ b/yuhyun/Implementation/기둥과 보 설치.js
@@ -1,0 +1,127 @@
+function solution(n, build_frame) {
+  const structure = new Structure(n + 1);
+  const fns = [
+    [
+      structure.deletePillar.bind(structure),
+      structure.addPillar.bind(structure),
+    ],
+    [structure.deleteBeam.bind(structure), structure.addBeam.bind(structure)],
+  ];
+
+  build_frame
+    .map(([x, y, a, b]) => [n - y, x, fns[a][b]])
+    .forEach(([row, col, fn]) => fn(row, col));
+
+  const structureArray = structure
+    .toArray()
+    .map(([row, col, type]) => [col, n - row, type]);
+
+  structureArray.sort(
+    ([xA, yA, typeA], [xB, yB, typeB]) => xA - xB || yA - yB || typeA - typeB
+  );
+
+  return structureArray;
+}
+
+function outOfRange(x, y, X, Y) {
+  return x < 0 || y < 0 || X <= x || Y <= y;
+}
+
+class Structure {
+  static #PILLAR = 0;
+  static #BEAM = 1;
+  static #DIR = [
+    [0, 1],
+    [1, 1],
+    [1, 0],
+    [1, -1],
+    [0, -1],
+    [-1, -1],
+    [-1, 0],
+    [-1, -1],
+  ];
+
+  #n;
+  #structure;
+
+  constructor(n) {
+    this.#n = n;
+    this.#structure = Array.from(Array(n), () =>
+      Array.from(Array(n), () => Array(2).fill(false))
+    );
+  }
+
+  addPillar(row, col) {
+    if (this.#isValidPillar(row, col)) {
+      this.#structure[row][col][Structure.#PILLAR] = true;
+    }
+  }
+
+  addBeam(row, col) {
+    if (this.#isValidBeam(row, col)) {
+      this.#structure[row][col][Structure.#BEAM] = true;
+    }
+  }
+
+  deletePillar(row, col) {
+    this.#delete(row, col, Structure.#PILLAR);
+  }
+
+  deleteBeam(row, col) {
+    this.#delete(row, col, Structure.#BEAM);
+  }
+
+  toArray() {
+    const result = [];
+    this.#structure.forEach((row, rowIndex) =>
+      row.forEach((col, colIndex) =>
+        col.forEach(
+          (exist, type) => exist && result.push([rowIndex, colIndex, type])
+        )
+      )
+    );
+    return result;
+  }
+
+  #delete(row, col, type) {
+    this.#structure[row][col][type] = false;
+    const canDelete = Structure.#DIR
+      .map(([dRow, dCol]) => [row + dRow, col + dCol])
+      .filter(
+        ([nextRow, nextCol]) => !outOfRange(nextRow, nextCol, this.#n, this.#n)
+      )
+      .every(
+        ([nextRow, nextCol]) =>
+          (!this.#getSafe(nextRow, nextCol, Structure.#PILLAR) ||
+            this.#isValidPillar(nextRow, nextCol)) &&
+          (!this.#getSafe(nextRow, nextCol, Structure.#BEAM) ||
+            this.#isValidBeam(nextRow, nextCol))
+      );
+
+    if (!canDelete) {
+      this.#structure[row][col][type] = true;
+    }
+  }
+
+  #isValidPillar(row, col) {
+    return (
+      row === this.#n - 1 ||
+      this.#getSafe(row + 1, col, Structure.#PILLAR) ||
+      this.#getSafe(row, col - 1, Structure.#BEAM) ||
+      this.#getSafe(row, col + 1, Structure.#BEAM)
+    );
+  }
+
+  #isValidBeam(row, col) {
+    return (
+      this.#getSafe(row + 1, col, Structure.#PILLAR) ||
+      this.#getSafe(row + 1, col + 1, Structure.#PILLAR) ||
+      (this.#getSafe(row, col - 1, Structure.#BEAM) &&
+        this.#getSafe(row, col + 1, Structure.#BEAM))
+    );
+  }
+
+  #getSafe(row, col, type) {
+    return this.#structure?.[row]?.[col]?.[type];
+  }
+}

--- a/yuhyun/Implementation/기둥과 보 설치.js
+++ b/yuhyun/Implementation/기둥과 보 설치.js
@@ -30,16 +30,6 @@ function outOfRange(x, y, X, Y) {
 class Structure {
   static #PILLAR = 0;
   static #BEAM = 1;
-  static #DIR = [
-    [0, 1],
-    [1, 1],
-    [1, 0],
-    [1, -1],
-    [0, -1],
-    [-1, -1],
-    [-1, 0],
-    [-1, -1],
-  ];
 
   #n;
   #structure;
@@ -85,18 +75,22 @@ class Structure {
 
   #delete(row, col, type) {
     this.#structure[row][col][type] = false;
-    const canDelete = Structure.#DIR
-      .map(([dRow, dCol]) => [row + dRow, col + dCol])
-      .filter(
-        ([nextRow, nextCol]) => !outOfRange(nextRow, nextCol, this.#n, this.#n)
-      )
-      .every(
-        ([nextRow, nextCol]) =>
-          (!this.#getSafe(nextRow, nextCol, Structure.#PILLAR) ||
-            this.#isValidPillar(nextRow, nextCol)) &&
-          (!this.#getSafe(nextRow, nextCol, Structure.#BEAM) ||
-            this.#isValidBeam(nextRow, nextCol))
-      );
+
+    let canDelete = true;
+    for (let r = 0; r < this.#structure.length && canDelete; r += 1) {
+      for (let c = 0; c < this.#structure[r].length && canDelete; c += 1) {
+        const [addedPillar, addedBeam] = this.#structure[r][c];
+        if (addedPillar && !this.#isValidPillar(r, c)) {
+          canDelete = false;
+          break;
+        }
+
+        if (addedBeam && !this.#isValidBeam(r, c)) {
+          canDelete = false;
+          break;
+        }
+      }
+    }
 
     if (!canDelete) {
       this.#structure[row][col][type] = true;
@@ -108,7 +102,7 @@ class Structure {
       row === this.#n - 1 ||
       this.#getSafe(row + 1, col, Structure.#PILLAR) ||
       this.#getSafe(row, col - 1, Structure.#BEAM) ||
-      this.#getSafe(row, col + 1, Structure.#BEAM)
+      this.#getSafe(row, col, Structure.#BEAM)
     );
   }
 

--- a/yuhyun/Implementation/셔틀버스.js
+++ b/yuhyun/Implementation/셔틀버스.js
@@ -1,0 +1,36 @@
+function solution(n, t, m, timetable) {
+  const 시 = 60;
+  const START = 9 * 시;
+  const shuttles = Array.from(Array(n), (_, offset) => [
+    START + t * offset,
+    [],
+  ]);
+
+  const minutes = timetable.map((time) => {
+    const [hour, min] = time.split(":").map(Number);
+    return hour * 시 + min;
+  });
+
+  minutes.sort((a, b) => a - b);
+
+  let crew = 0;
+  const nCrew = minutes.length;
+  shuttles.forEach(([shuttleMinute, members]) => {
+    while (crew < nCrew && members.length < m) {
+      const crewMinute = minutes[crew];
+      if (crewMinute > shuttleMinute) {
+        break;
+      }
+
+      members.push(crewMinute);
+      crew += 1;
+    }
+  });
+
+  const [shuttleMinute, members] = shuttles.pop();
+  const con = members.length !== m ? shuttleMinute : members.at(-1) - 1;
+
+  return [Math.floor(con / 시), con % 시]
+    .map((num) => num.toString().padStart(2, "0"))
+    .join(":");
+}

--- a/yuhyun/Implementation/행렬과 연산.js
+++ b/yuhyun/Implementation/행렬과 연산.js
@@ -1,0 +1,147 @@
+function solution(rc, operations) {
+  const firstColumns = new Deque();
+  const lastColumns = new Deque();
+  const middleRows = new Deque();
+
+  rc.forEach((row) => {
+    const { length } = row;
+    firstColumns.addLast(row[0]);
+    lastColumns.addLast(row.at(-1));
+
+    const deque = new Deque();
+    for (let index = 1; index < length - 1; index += 1) {
+      deque.addLast(row[index]);
+    }
+    middleRows.addLast(deque);
+  });
+
+  const shiftRow = () => {
+    firstColumns.addFirst(firstColumns.removeLast());
+    lastColumns.addFirst(lastColumns.removeLast());
+    middleRows.addFirst(middleRows.removeLast());
+  };
+
+  const rotate = () => {
+    middleRows.first().addFirst(firstColumns.removeFirst());
+    lastColumns.addFirst(middleRows.first().removeLast());
+    middleRows.last().addLast(lastColumns.removeLast());
+    firstColumns.addLast(middleRows.last().removeFirst());
+  };
+
+  const fns = {
+    ShiftRow: shiftRow,
+    Rotate: rotate,
+  };
+
+  operations.forEach((operation) => fns[operation]());
+
+  const result = [];
+  while (!firstColumns.isEmpty()) {
+    const row = [];
+    row.push(firstColumns.removeFirst());
+
+    const middleRow = middleRows.removeFirst().toArray();
+    if (middleRow.length) {
+      row.push(...middleRow);
+    }
+
+    row.push(lastColumns.removeFirst());
+    result.push(row);
+  }
+
+  return result;
+}
+
+class Node {
+  constructor(value) {
+    this.value = value;
+    this.prev = null;
+    this.next = null;
+  }
+}
+
+class Deque {
+  head;
+  tail;
+  size = 0;
+
+  addFirst(value) {
+    if (this.isEmpty()) {
+      this.addLast(value);
+      return;
+    }
+
+    const node = new Node(value);
+    this.head.prev = node;
+    node.next = this.head;
+    this.head = node;
+    this.size += 1;
+  }
+
+  addLast(value) {
+    const node = new Node(value);
+    if (this.isEmpty()) {
+      this.head = node;
+    } else {
+      this.tail.next = node;
+      node.prev = this.tail;
+    }
+
+    this.tail = node;
+    this.size += 1;
+  }
+
+  removeFirst() {
+    if (this.isEmpty()) {
+      return null;
+    }
+
+    if (this.size === 1) {
+      return this.removeLast();
+    }
+
+    const value = this.head.value;
+    this.head.prev = null;
+    this.head = this.head.next;
+    this.size -= 1;
+    return value;
+  }
+
+  removeLast() {
+    if (this.isEmpty()) {
+      return null;
+    }
+
+    const value = this.tail.value;
+    if (this.size === 1) {
+      this.head = this.tail = undefined;
+    } else {
+      this.tail = this.tail.prev;
+      this.tail.next = null;
+    }
+    this.size -= 1;
+    return value;
+  }
+
+  first() {
+    return this.head?.value;
+  }
+
+  last() {
+    return this.tail?.value;
+  }
+
+  isEmpty() {
+    return this.size === 0;
+  }
+
+  toArray() {
+    let cur = this.head;
+    const result = [];
+    while (cur) {
+      result.push(cur.value);
+      cur = cur.next;
+    }
+    return result;
+  }
+}

--- a/yuhyun/ShortestPath/등산코스 정하기.js
+++ b/yuhyun/ShortestPath/등산코스 정하기.js
@@ -1,0 +1,77 @@
+function solution(n, paths, gates, summits) {
+  const graph = createGraph(n, paths);
+
+  const summitSets = new Set(summits);
+  const minPairs = calcMinPairs(graph, gates, summitSets).filter(([node]) =>
+    summitSets.has(node)
+  );
+
+  const SUMMIT = 0;
+  const MIN_INTENSITY = 1;
+  minPairs.sort(
+    (a, b) => a[MIN_INTENSITY] - b[MIN_INTENSITY] || a[SUMMIT] - b[SUMMIT]
+  );
+
+  return minPairs[0];
+}
+
+function calcMinPairs(graph, gates, summits) {
+  const n = graph.length;
+  const queue = new Queue();
+
+  const MIN_INTENSITY = 1;
+  const minIntensities = Array(n).fill(Infinity);
+
+  gates.forEach((gate) => {
+    minIntensities[gate] = 0;
+    queue.push([gate, 0]);
+  });
+
+  while (!queue.isEmpty()) {
+    const [node, minIntensity] = queue.pop();
+    if (minIntensities[node] !== minIntensity) {
+      continue;
+    }
+
+    graph[node]
+      .map(([next, weight]) => [next, Math.max(weight, minIntensity)])
+      .filter(
+        ([next, nextMinIntensity]) => nextMinIntensity < minIntensities[next]
+      )
+      .forEach(([next, nextMinIntensity]) => {
+        minIntensities[next] = nextMinIntensity;
+        if (!summits.has(next)) {
+          queue.push([next, nextMinIntensity]);
+        }
+      });
+  }
+
+  return minIntensities.map((minIntensity, node) => [node, minIntensity]);
+}
+
+function createGraph(n, paths) {
+  const PADDING = 1;
+  const result = Array.from(Array(n + PADDING), () => []);
+  paths.forEach(([nodeA, nodeB, weight]) => {
+    result[nodeA].push([nodeB, weight]);
+    result[nodeB].push([nodeA, weight]);
+  });
+  return result;
+}
+
+class Queue {
+  #queue = [];
+  #head = 0;
+
+  push(value) {
+    this.#queue.push(value);
+  }
+
+  pop() {
+    return this.isEmpty() ? null : this.#queue[this.#head++];
+  }
+
+  isEmpty() {
+    return this.#queue.length === this.#head;
+  }
+}

--- a/yuhyun/ShortestPath/미로 탈출.js
+++ b/yuhyun/ShortestPath/미로 탈출.js
@@ -1,0 +1,86 @@
+function solution(n, start, end, roads, traps) {
+  const shortestPaths = findShortestPaths(
+    n,
+    start,
+    createAllGraph(n, roads, traps),
+    new Map(traps.map((trap, index) => [trap, index]))
+  );
+
+  return Math.min(...shortestPaths[end]);
+}
+
+function findShortestPaths(n, start, graphs, traps) {
+  const INIT_STATE = 0;
+  const INIT_PATH = 0;
+
+  const nState = 2 ** traps.size;
+  const result = Array.from(Array(n + 1), () => Array(nState).fill(Infinity));
+  const queue = new Queue();
+  result[start][INIT_STATE] = INIT_PATH;
+  queue.push([start, INIT_PATH, INIT_STATE]);
+
+  while (!queue.isEmpty()) {
+    const [node, path, state] = queue.pop();
+    if (result[node][state] !== path) {
+      continue;
+    }
+
+    graphs[state][node]
+      .map(([next, weight]) => [
+        next,
+        path + weight,
+        traps.has(next) ? state ^ (1 << traps.get(next)) : state,
+      ])
+      .filter(
+        ([next, nextPath, nextState]) => nextPath < result[next][nextState]
+      )
+      .forEach(([next, nextPath, nextState]) => {
+        result[next][nextState] = nextPath;
+        queue.push([next, nextPath, nextState]);
+      });
+  }
+
+  return result;
+}
+
+function createAllGraph(n, roads, traps) {
+  const nTrap = traps.length;
+  return Array.from(Array(2 ** nTrap), (_, state) => {
+    const curRoads = roads.map((road) => [...road]);
+    traps
+      .filter((_, index) => state & (1 << index))
+      .forEach((trap) => reverseEdges(trap, curRoads));
+    return createGraph(n, curRoads);
+  });
+}
+
+function reverseEdges(node, edges) {
+  edges.forEach(([from, to, weight], index) => {
+    if (from === node || to === node) {
+      edges[index] = [to, from, weight];
+    }
+  });
+}
+
+function createGraph(n, roads) {
+  const result = Array.from(Array(n + 1), () => []);
+  roads.forEach(([from, to, weight]) => result[from].push([to, weight]));
+  return result;
+}
+
+class Queue {
+  #queue = [];
+  #head = 0;
+
+  push(value) {
+    this.#queue.push(value);
+  }
+
+  pop() {
+    return this.isEmpty() ? null : this.#queue[this.#head++];
+  }
+
+  isEmpty() {
+    return this.#queue.length === this.#head;
+  }
+}


### PR DESCRIPTION
## 등산코스 정하기
- BFS로 모든 출입구부터 모든 노드까지의 최소 intensity 구하기
- 현재 방문한 노드가 산봉우리라면 queue에 추가하지 않는 조건 필요

## 미로 탈출
- [갓킹독님 풀이](https://blog.encrypted.gg/1002) 봄
- 함정 on/off 상태에 따른 그래프(`[함정on/off 상태][행][열]`)를 모두 만들고 BFS 로 최단 거리 구함
- 함정 상태에 따라 그래프에 노드와 간선을 추가하면 다익스트라로 풀 수 있는 것 같은데 어떻게 구현해야할 지 감이 안 옴..

## 기둥과 보 설치
- 14.4 / 100.0 ..
- 삭제 로직에서 삭제한 위치에서 인접한 8방향만 유효한지 검사했는데, 전체 검사로 변경하니 통과! (근데 왜 다 검사해야 하지..?)

## 셔틀버스
- 마지막 셔틀버스에 
	- `m` 명이 다 탔다면 마지막에 도착한 시간보다 1분 일찍 타면 됨
	- 아니라면 셔틀버스 시간에 타면 됨

## 행렬과 연산
- Deque로 `ShiftRow` 시간 복잡도를 $O(1)$로, `Rotate` 시간 복잡도를 $O(rc)$로 해서 아슬아슬하게 통과할 줄 알았는데 어림도 없었음
- [카카오 해설](https://tech.kakao.com/2022/07/13/2022-coding-test-summer-internship/) 봄;;
- 2x2 행렬일 때 첫 번째와 마지막 원소가 없는 중간 행들에는 값이 없기 때문에 `Rotate`와 행렬로 변환할 때 조심해야 함



