### PR TITLE
Week31: 송민형 문제풀이

### DIFF
--- a/minhyung/week31/(1)1918: 후위 표기식.js
+++ b/minhyung/week31/(1)1918: 후위 표기식.js
@@ -1,0 +1,101 @@
+//https://www.acmicpc.net/problem/1918
+// prettier-ignore
+const stdin = process.platform === 'linux' ? require('fs').readFileSync(0, 'utf-8').trim().split('\n') : `
+A*(B+C)
+`.trim().split('\n');
+
+function isSame(compare, arr) {
+  if (Array.isArray(arr)) {
+    return arr.some((element) => element === compare);
+  } else {
+    return compare === arr;
+  }
+}
+
+function popElementsWithCondition(arr, breakCondition) {
+  let result = "";
+
+  while (arr.length > 0) {
+    if (isSame(arr.at(-1), "(")) break;
+    if (breakCondition?.(arr.at(-1))) break;
+
+    const pop = arr.pop();
+    result += pop;
+  }
+
+  return result;
+}
+
+function popEveryElements(arr) {
+  return popElementsWithCondition(arr);
+}
+
+function popElementsBeforeBrackeet(arr) {
+  let result = "";
+
+  while (arr.length > 0) {
+    const pop = arr.pop();
+    if (isSame(pop, "(")) break;
+    result += pop;
+  }
+
+  return result;
+}
+
+function solution(string) {
+  const stack = [];
+  let result = "";
+
+  for (const char of string) {
+    if (isSame(char, ["(", "*", "/", "+", "-"])) {
+      if (isSame(char, ["*", "/"])) {
+        // stack의 마지막 요소가 + - 면 while문을 빠져나옴
+        result += popElementsWithCondition(stack, (el) => isSame(el, ["+", "-"]));
+      } else if (isSame(char, ["+", "-"])) {
+        // stack의 모든 요소를 pop함
+        result += popEveryElements(stack);
+      }
+      // 우선순위에 따라 stack에서 pop한후 현재 요소를 stack에 넣어줌
+      stack.push(char);
+    } else if (isSame(char, ")")) {
+      result += popElementsBeforeBrackeet(stack);
+    }
+    // 문자열
+    else {
+      result += char;
+    }
+  }
+
+  if (stack.length > 0) {
+    result += popElementsBeforeBrackeet(stack);
+  }
+  return result;
+}
+
+console.log(solution(stdin[0]));
+
+// [
+//   ["A*(B+C)", "ABC+*"],
+//   ["A+B", "AB+"],
+//   ["A+B*C", "ABC*+"],
+//   ["A+B*C-D/E", "ABC*+DE/-"],
+//   ["(A+((B+C)+E))", "ABC+E++"],
+//   ["A*B*C", "AB*C*"],
+//   ["A+B+(C*D+E)", "AB+CD*E++"],
+//   ["A+B*(C*D+E)", "ABCD*E+*+"],
+// ].forEach(([input, answer]) => {
+//   const result = solution(input);
+//   if (result === answer) return;
+//   console.log(`틀림\n  in     : ${input}\n  result : ${result}\n  correct: ${answer}`);
+// });
+
+// 문자열 스택, 기호 스택
+// 만날 수 있는거
+
+// (     : 스택에 넣음
+// )     : ( 를 만날 때 까지 스택에서 빼서 결과에 추가함
+// * /   : * / 만나기 전까지의 모든 요소를 스택에서 빼서 결과에 추가함
+// + -   : + - 를 만나기 전까지 모든 요소를 스택에서 빼서 결과에 추가함
+// 문자열  : 결과에 더함
+
+// 마지막에 스택에 있는걸 결과에 추가해줌

--- a/minhyung/week31/(2)17070: 파이프 옮기기1.js
+++ b/minhyung/week31/(2)17070: 파이프 옮기기1.js
@@ -1,0 +1,78 @@
+//https://www.acmicpc.net/problem/17070
+//prettier-ignore
+const stdin = process.platform === 'linux' ? require('fs').readFileSync(0, 'utf-8').trim().split('\n') : `
+22
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+`.trim().split('\n');
+//prettier-ignore
+const input = (() => { let l = 0; return () => stdin[l++].split(' ')})();
+
+const WALL = "1";
+
+class Pipe {
+  constructor(horizontal, vertical, diagonal) {
+    this.horizontal = horizontal;
+    this.vertical = vertical;
+    this.diagonal = diagonal;
+  }
+  sumEvery = () => this.horizontal + this.vertical + this.diagonal;
+  sumLeft = () => this.horizontal + this.diagonal;
+  sumTop = () => this.vertical + this.diagonal;
+}
+
+function isPipe(board, y, x) {
+  return board[y]?.[x] instanceof Pipe;
+}
+
+function solution(N, board) {
+  board[0][0] = new Pipe(0, 0, 0);
+  board[0][1] = new Pipe(1, 0, 0);
+
+  // 가로: 왼쪽 가로, 왼쪽 대각
+  // 세로: 위 세로, 위 대각
+  // 대각: 왼쪽위 가로, 왼쪽위 세로, 왼쪽위 대각
+  // 근데 현재가 2거나 해당 위치를 볼 때 2면 더하지 않음
+  for (let y = 0; y < N; y++) {
+    for (let x = 1; x < N; x++) {
+      if (y === 0 && x === 1) continue;
+      if (board[y][x] === WALL) continue;
+
+      const left = board[y]?.[x - 1]?.sumLeft?.() ?? 0;
+      const top = board[y - 1]?.[x]?.sumTop?.() ?? 0;
+      // 왼쪽, 위에 아무것도 없어야 대각선 이동이 가능함
+      // 이동이 가능하다면 대각선의 값들을 더해줌
+      // 왼쪽과 위가 파이프 === 이동 가능한 위치와 같은 의미
+      let canMoveDiagonal = isPipe(board, y, x - 1) && isPipe(board, y - 1, x);
+      const diagonal = canMoveDiagonal ? board[y - 1]?.[x - 1]?.sumEvery?.() ?? 0 : 0;
+
+      board[y][x] = new Pipe(left, top, diagonal);
+    }
+  }
+
+  return board[N - 1][N - 1]?.sumEvery?.() ?? 0;
+}
+
+const N = Number(input());
+const board = Array.from({ length: N }, () => input());
+console.log(solution(N, board));

--- a/minhyung/week31/(3)10775: 공항.js
+++ b/minhyung/week31/(3)10775: 공항.js
@@ -1,0 +1,56 @@
+//https://www.acmicpc.net/problem/10775
+//prettier-ignore
+const stdin = process.platform === 'linux' ? require('fs').readFileSync(0, 'utf-8').trim().split('\n') : `
+5
+4
+1
+2
+3
+3
+`.trim().split('\n');
+//prettier-ignore
+const input = (() => { let l = 0; return () => Number(stdin[l++])})();
+function useUnionFind(length) {
+  const p = Array.from({ length }, (_, idx) => idx);
+
+  function union(a, b) {
+    const x = find(a);
+    const y = find(b);
+
+    if (x !== y) p[x] = y;
+  }
+
+  function find(a) {
+    if (p[a] !== a) {
+      p[a] = find(p[a]);
+    }
+    return p[a];
+  }
+  return { union, find, p };
+}
+function solution(gate, airplanes) {
+  const { union, find, p } = useUnionFind(gate + 1);
+  let result = 0;
+
+  for (const gate of airplanes) {
+    const next = find(gate);
+
+    if (next === 0) break;
+
+    union(gate, next - 1);
+    result++;
+  }
+
+  return result;
+}
+
+const G = input(); // 게이트
+const P = input(); // 비행기 대수
+const airplanes = Array.from({ length: P }, () => input());
+console.log(solution(G, airplanes));
+
+// 처음에 틀린 이유: 비행기를 더이상 못대면 break해야 하는데 하지 않음
+// 두번째 틀린 이유: find(gate) !== find(gate - 1) 일 때 비행기를 대도록 했는데
+//               이러면 비행기가 두대까지는 같은곳에 들어가는데 그 다음 비행기부터는 들어가지 않음
+//               gate, gate-1이 항상 같을것 이기 때문
+//               그래서 gate와 find(gate)-1의 값을 가지고 union함

--- a/minhyung/week31/(4)1208: 부분수열의 합2.js
+++ b/minhyung/week31/(4)1208: 부분수열의 합2.js
@@ -1,0 +1,39 @@
+//https://www.acmicpc.net/problem/1208
+//prettier-ignore
+const stdin = process.platform === 'linux' ? require('fs').readFileSync(0, 'utf-8').trim().split('\n') : `
+5 0
+-7 -3 -2 5 8
+`.trim().split('\n');
+//prettier-ignore
+const input = (() => { let l = 0; return () => stdin[l++].split(' ').map(Number)})();
+
+function getSums(arr, now, end, sum = 0, result = new Map()) {
+  result.set(sum, (result.get(sum) ?? 0) + 1);
+
+  for (let i = now; i < end; i++) {
+    getSums(arr, i + 1, end, sum + arr[i], result);
+  }
+
+  return result;
+}
+function solution(N, goal, arr) {
+  const midIdx = Math.floor(arr.length / 2);
+  const leftSums = getSums(arr, 0, midIdx);
+  const rightSums = getSums(arr, midIdx, N);
+  let result = 0;
+
+  rightSums.forEach((count, num) => {
+    if (leftSums.has(S - num)) {
+      result += leftSums.get(S - num) * count;
+    }
+  });
+
+  return goal === 0 ? result - 1 : result;
+}
+
+const [N, S] = input();
+const arr = input();
+
+console.log(solution(N, S, arr));
+
+// 그냥 조합 = 2^40 = 개큼


### PR DESCRIPTION
# 1918: 후위 표기식
연산자의 우선순위에 따라 스택에 넣고 빼는 문제 (곱연산자 우선순위 > 합연산자 우선순위)
곱연산: 합연산자를 만날 때 까지 모든 스택요소를 뺌 , 그 후 현재 연산자를 스택에 넣음
합연산: 모든 연산자를 뺌, 그 후 현재 연산자를 스택에 넣음
(, 문자: 그냥 스택에 넣음
)        : ( 를 만날 때 까지 스택에서 모든 요소를 뺌

# 17070: 파이프 옮기기
bfs나 dfs인줄 알았지만 규칙이 존재해서 dp로 풀 수 있던 문제

# 10775: 공항
유니온 파인드로 풀면 되는데 지문 설명을 너무 대충해놔서 문제를 이해하는 시간이 더 걸려버림
union(현재 게이트, 현재 게이트-1) 이런식으로 유니온 파인드로 풀면됨

# 부분수열의 합2
[두 배열의 합](https://www.acmicpc.net/problem/2143) 이 문제랑 거의 흡사한 문제
그런데 최대 40개의 배열을 두개로 잘라내는 아이디어를 떠올리지 못해 결국 다른사람의 해설을 봄